### PR TITLE
Add Ruby scripting extension

### DIFF
--- a/extension/ruby/build.gradle.kts
+++ b/extension/ruby/build.gradle.kts
@@ -1,0 +1,82 @@
+import org.gradle.language.jvm.tasks.ProcessResources
+
+plugins {
+    `java-library`
+}
+
+base {
+    archivesName.set("${property("mod_id")}-ruby")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(property("java_version").toString().toInt()))
+    }
+    withSourcesJar()
+}
+
+repositories {
+    mavenCentral()
+}
+
+// Get minecraft version from stonecutter.active file
+val minecraftVersion = rootProject.file("stonecutter.active").takeIf { it.exists() }
+    ?.readText()?.trim()?.ifEmpty { null }
+    ?: throw GradleException("stonecutter.active is empty; set an active version first")
+
+// Configuration for runtime dependencies to embed in the extension jar
+val embedDeps by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    // Depends on extension module
+    implementation(project(":extension"))
+
+    // Compile against shared common code
+    compileOnly(project(":common:${minecraftVersion}"))
+    compileOnly("org.jetbrains:annotations:20.1.0")
+
+    // JRuby runtime - embedded into the extension jar so users don't need it on the classpath
+    implementation("org.jruby:jruby-complete:9.4.5.0")
+    add(embedDeps.name, "org.jruby:jruby-complete:9.4.5.0")
+
+    // Common library dependencies, google deps must align with neoforged
+    implementation("com.google.guava:guava:31.1-jre")
+    implementation("com.google.code.gson:gson:2.10")
+    implementation("org.slf4j:slf4j-api:2.0.16")
+
+    // Test dependencies
+    testImplementation(project(":extension"))
+    testImplementation(project(":common:${minecraftVersion}"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testImplementation("org.jetbrains:annotations:20.1.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+}
+
+// Collect embedded dependency paths for the json file
+fun getEmbeddedDepPaths(): String =
+    embedDeps.files.joinToString(", ") { file ->
+        "\"META-INF/jsmacroscedeps/${file.name}\""
+    }
+
+// Process resources to expand dependencies placeholder
+tasks.named<ProcessResources>("processResources") {
+    filesMatching("jsmacrosce.ext.jruby.json") {
+        expand(mapOf("dependencies" to getEmbeddedDepPaths()))
+    }
+}
+
+// Embed dependencies into the extension jar
+tasks.named<Jar>("jar") {
+    dependsOn(embedDeps)
+    from(embedDeps) {
+        into("META-INF/jsmacroscedeps")
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/client/JRubyExtension.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/client/JRubyExtension.java
@@ -1,0 +1,128 @@
+package com.jsmacrosce.jsmacros.jruby.client;
+
+import com.google.common.collect.Sets;
+import org.jruby.RubyException;
+import org.jruby.embed.EvalFailedException;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
+import org.jruby.runtime.builtin.IRubyObject;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.extensions.LanguageExtension;
+import com.jsmacrosce.jsmacros.core.extensions.LibraryExtension;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.language.BaseWrappedException;
+import com.jsmacrosce.jsmacros.core.library.BaseLibrary;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyLanguageDefinition;
+import com.jsmacrosce.jsmacros.jruby.library.impl.FWrapper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+
+public class JRubyExtension implements LanguageExtension, LibraryExtension {
+
+    private static JRubyLanguageDefinition languageDefinition;
+
+    @Override
+    public String getExtensionName() {
+        return "jruby";
+    }
+
+    @Override
+    public void init(Core<?, ?> runner) {
+        Thread t = new Thread(() -> {
+            ScriptingContainer instance = new ScriptingContainer();
+            instance.runScriptlet("p \"Ruby Pre-Loaded\"");
+            instance.terminate();
+        }, "JRuby-Preload");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public ExtMatch extensionMatch(File file) {
+        if (file.getName().endsWith(".rb")) {
+            if (file.getName().contains(getExtensionName())) {
+                return ExtMatch.MATCH_WITH_NAME;
+            } else {
+                return ExtMatch.MATCH;
+            }
+        }
+        return ExtMatch.NOT_MATCH;
+    }
+
+    @Override
+    public String defaultFileExtension() {
+        return "rb";
+    }
+
+    @Override
+    public synchronized BaseLanguage<?, ?> getLanguage(Core<?, ?> runner) {
+        if (languageDefinition == null) {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(JRubyExtension.class.getClassLoader());
+            try {
+                languageDefinition = new JRubyLanguageDefinition(this, runner);
+            } finally {
+                Thread.currentThread().setContextClassLoader(classLoader);
+            }
+        }
+        return languageDefinition;
+    }
+
+    @Override
+    public Set<Class<? extends BaseLibrary>> getLibraries() {
+        return Sets.newHashSet(FWrapper.class);
+    }
+
+    @Override
+    public BaseWrappedException<?> wrapException(Throwable ex) {
+        if (!(ex instanceof EvalFailedException)) return null;
+        Throwable cause = ex.getCause();
+        if (cause instanceof RaiseException) {
+            RubyException e = ((RaiseException) cause).getException();
+            StackTraceElement[] frames = Arrays.stream(e.getBacktraceElements())
+                    .map(RubyStackTraceElement::asStackTraceElement)
+                    .toArray(StackTraceElement[]::new);
+            return new BaseWrappedException<>(e, e.getMessageAsJavaString(), null, buildTrace(frames));
+        }
+        return new BaseWrappedException<>(cause, cause.getClass().getName() + ": " + cause.getMessage(), null, buildTrace(cause.getStackTrace()));
+    }
+
+    private BaseWrappedException<StackTraceElement> buildTrace(StackTraceElement[] frames) {
+        BaseWrappedException<StackTraceElement> head = null;
+        for (int i = frames.length - 1; i >= 0; i--) {
+            StackTraceElement frame = frames[i];
+            String cls = frame.getClassName();
+            if ("org.jruby.embed.internal.EmbedEvalUnitImpl".equals(cls)) {
+                // upstream ran here — discard everything we've accumulated above it in the chain
+                head = null;
+                continue;
+            }
+            if (cls.startsWith("org.jruby")) continue;
+            BaseWrappedException.SourceLocation loc;
+            if ("RUBY".equals(cls)) {
+                String fileName = frame.getFileName();
+                loc = new BaseWrappedException.GuestLocation(
+                        fileName != null ? new File(fileName) : null,
+                        -1, -1, frame.getLineNumber(), -1);
+            } else {
+                loc = new BaseWrappedException.HostLocation(cls + " " + frame.getLineNumber());
+            }
+            head = new BaseWrappedException<>(frame, frame.getMethodName(), loc, head);
+        }
+        return head;
+    }
+
+    @Override
+    public boolean isGuestObject(Object o) {
+        return o instanceof IRubyObject;
+    }
+
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyLanguageDefinition.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyLanguageDefinition.java
@@ -1,0 +1,81 @@
+package com.jsmacrosce.jsmacros.jruby.language.impl;
+
+import org.jruby.embed.LocalContextScope;
+import org.jruby.embed.ScriptingContainer;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.config.ScriptTrigger;
+import com.jsmacrosce.jsmacros.core.event.BaseEvent;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.language.EventContainer;
+import com.jsmacrosce.jsmacros.jruby.client.JRubyExtension;
+
+import org.jetbrains.annotations.Nullable;
+import java.io.File;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JRubyLanguageDefinition extends BaseLanguage<ScriptingContainer, JRubyScriptContext> {
+    public JRubyLanguageDefinition(JRubyExtension extension, Core<?, ?> runner) {
+        super(extension, runner);
+    }
+
+    private void runInstance(EventContainer<JRubyScriptContext> ctx, BaseEvent event, ScriptletRunner scriptlet, @Nullable Path cwd) throws Exception {
+        ScriptingContainer instance = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
+        ctx.getCtx().setContext(instance);
+
+        if (cwd != null) {
+            instance.setCurrentDirectory(cwd.toString());
+        }
+
+        retrieveLibs(ctx.getCtx()).forEach((name, lib) -> {
+            // "Time" is a built-in Ruby class; expose jsmacros' Time library under FTime instead.
+            String bindName = "Time".equals(name) ? "FTime" : name;
+            instance.put(bindName, lib);
+        });
+        instance.put("event", event);
+        instance.put("file", ctx.getCtx().getFile());
+        instance.put("context", ctx);
+
+        scriptlet.run(instance);
+    }
+
+    @Override
+    protected void exec(EventContainer<JRubyScriptContext> ctx, ScriptTrigger macro, BaseEvent event) throws Exception {
+        File file = ctx.getCtx().getFile();
+        runInstance(ctx, event, instance -> {
+            try (Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                instance.runScriptlet(reader, file.getAbsolutePath());
+            }
+        }, parentPathOf(file));
+    }
+
+    @Override
+    protected void exec(EventContainer<JRubyScriptContext> ctx, String lang, String script, BaseEvent event) throws Exception {
+        File file = ctx.getCtx().getFile();
+        runInstance(ctx, event, instance -> {
+            if (file != null) {
+                instance.runScriptlet(new StringReader(script), file.getAbsolutePath());
+            } else {
+                instance.runScriptlet(script);
+            }
+        }, parentPathOf(file));
+    }
+
+    @Override
+    public JRubyScriptContext createContext(BaseEvent event, File path) {
+        return new JRubyScriptContext(runner, event, path);
+    }
+
+    private static @Nullable Path parentPathOf(@Nullable File f) {
+        if (f == null) return null;
+        File parent = f.getParentFile();
+        return parent != null ? parent.toPath() : null;
+    }
+
+    private interface ScriptletRunner {
+        void run(ScriptingContainer instance) throws Exception;
+    }
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyScriptContext.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyScriptContext.java
@@ -1,0 +1,29 @@
+package com.jsmacrosce.jsmacros.jruby.language.impl;
+
+import org.jruby.embed.ScriptingContainer;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.event.BaseEvent;
+import com.jsmacrosce.jsmacros.core.language.BaseScriptContext;
+
+import java.io.File;
+
+public class JRubyScriptContext extends BaseScriptContext<ScriptingContainer> {
+    public JRubyScriptContext(Core<?, ?> runner, BaseEvent event, File file) {
+        super(runner, event, file);
+    }
+
+    @Override
+    public synchronized void closeContext() {
+        super.closeContext();
+        ScriptingContainer ctx = getContext();
+        if (ctx != null) {
+            ctx.terminate();
+        }
+    }
+
+    @Override
+    public boolean isMultiThreaded() {
+        return true;
+    }
+
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/library/impl/FWrapper.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/library/impl/FWrapper.java
@@ -1,0 +1,152 @@
+package com.jsmacrosce.jsmacros.jruby.library.impl;
+
+import org.jruby.RubyMethod;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import com.jsmacrosce.jsmacros.core.MethodWrapper;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.library.IFWrapper;
+import com.jsmacrosce.jsmacros.core.library.Library;
+import com.jsmacrosce.jsmacros.core.library.PerExecLanguageLibrary;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyLanguageDefinition;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyScriptContext;
+
+@Library(value = "JavaWrapper", languages = JRubyLanguageDefinition.class)
+public class FWrapper extends PerExecLanguageLibrary<ScriptingContainer, JRubyScriptContext> implements IFWrapper<RubyMethod> {
+
+    public FWrapper(JRubyScriptContext context, Class<? extends BaseLanguage<ScriptingContainer, JRubyScriptContext>> language) {
+        super(context, language);
+    }
+
+    @Override
+    public <A, B, R> MethodWrapper<A, B, R, ?> methodToJava(RubyMethod c) {
+        return new RubyMethodWrapper<>(c, true, ctx);
+    }
+
+    @Override
+    public <A, B, R> MethodWrapper<A, B, R, ?> methodToJavaAsync(RubyMethod c) {
+        return new RubyMethodWrapper<>(c, false, ctx);
+    }
+
+    @Override
+    public void stop() {
+        ctx.closeContext();
+    }
+
+    private static class RubyMethodWrapper<T, U, R> extends MethodWrapper<T, U, R, JRubyScriptContext> {
+        private final RubyMethod fn;
+        private final boolean await;
+
+        RubyMethodWrapper(RubyMethod fn, boolean await, JRubyScriptContext ctx) {
+            super(ctx);
+            this.fn = fn;
+            this.await = await;
+        }
+
+        private Object callFn(Object... params) {
+            ThreadContext threadContext = ctx.getContext().getProvider().getRuntime().getCurrentContext();
+            threadContext.pushNewScope(threadContext.getCurrentStaticScope());
+            try {
+                IRubyObject[] rubyObjects = JavaUtil.convertJavaArrayToRuby(threadContext.runtime, params);
+                return fn.call(threadContext, rubyObjects, threadContext.getFrameBlock()).toJava(Object.class);
+            } finally {
+                threadContext.popScope();
+            }
+        }
+
+        private void innerAccept(Object... params) {
+            if (await) {
+                innerApply(params);
+                return;
+            }
+
+            Thread t = new Thread(() -> {
+                ctx.bindThread(Thread.currentThread());
+                try {
+                    callFn(params);
+                } catch (Throwable ex) {
+                    ctx.runner.profile.logError(ex);
+                } finally {
+                    ctx.unbindThread(Thread.currentThread());
+                    ctx.runner.profile.joinedThreadStack.remove(Thread.currentThread());
+                    ctx.releaseBoundEventIfPresent(Thread.currentThread());
+                }
+            }, "JRuby-JavaWrapper");
+            t.setDaemon(true);
+            t.start();
+        }
+
+        @SuppressWarnings("unchecked")
+        private <R2> R2 innerApply(Object... params) {
+            if (ctx.getBoundThreads().contains(Thread.currentThread())) {
+                return (R2) callFn(params);
+            }
+
+            try {
+                ctx.bindThread(Thread.currentThread());
+                if (ctx.runner.profile.checkJoinedThreadStack()) {
+                    ctx.runner.profile.joinedThreadStack.add(Thread.currentThread());
+                }
+                return (R2) callFn(params);
+            } catch (Throwable ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                ctx.releaseBoundEventIfPresent(Thread.currentThread());
+                ctx.unbindThread(Thread.currentThread());
+                ctx.runner.profile.joinedThreadStack.remove(Thread.currentThread());
+            }
+        }
+
+        @Override
+        public void accept(T t) {
+            innerAccept(t);
+        }
+
+        @Override
+        public void accept(T t, U u) {
+            innerAccept(t, u);
+        }
+
+        @Override
+        public R apply(T t) {
+            return innerApply(t);
+        }
+
+        @Override
+        public R apply(T t, U u) {
+            return innerApply(t, u);
+        }
+
+        @Override
+        public boolean test(T t) {
+            return (boolean) innerApply(t);
+        }
+
+        @Override
+        public boolean test(T t, U u) {
+            return (boolean) innerApply(t, u);
+        }
+
+        @Override
+        public void run() {
+            innerAccept();
+        }
+
+        @Override
+        public int compare(T o1, T o2) {
+            Object result = innerApply(o1, o2);
+            if (!(result instanceof Number)) {
+                throw new ClassCastException("Ruby comparator must return a numeric value, got: " + result);
+            }
+            return ((Number) result).intValue();
+        }
+
+        @Override
+        public R get() {
+            return innerApply();
+        }
+    }
+
+}

--- a/extension/ruby/src/main/resources/META-INF/services/com.jsmacrosce.jsmacros.core.extensions.Extension
+++ b/extension/ruby/src/main/resources/META-INF/services/com.jsmacrosce.jsmacros.core.extensions.Extension
@@ -1,0 +1,1 @@
+com.jsmacrosce.jsmacros.jruby.client.JRubyExtension

--- a/extension/ruby/src/main/resources/jsmacrosce.ext.jruby.json
+++ b/extension/ruby/src/main/resources/jsmacrosce.ext.jruby.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": [${dependencies}]
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ include("extension")
 include("extension:graal")
 include("extension:graal:js")
 include("extension:graal:python")
+include("extension:ruby")
 
 stonecutter {
     kotlinController = true

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -145,7 +145,8 @@ val loaders = listOf("fabric", "neoforge")
 
 data class ExtensionSpec(val path: String, val extId: String)
 val jsmExtensions: List<ExtensionSpec> = listOf(
-    ExtensionSpec(path = ":extension:graal:python", extId = "graalpy")
+    ExtensionSpec(path = ":extension:graal:python", extId = "graalpy"),
+    ExtensionSpec(path = ":extension:ruby", extId = "jruby")
 )
 
 val artifactBaseName = providers.provider { "$modId-$mcVersion-$channel-$version" }


### PR DESCRIPTION
## Summary

Adds a JRuby 9.4.5 language extension as `:extension:ruby`, providing `.rb` script support. New `ExtensionSpec(extId = "jruby")` entry in `stonecutter.gradle.kts` wires it into the multi-version build. JRuby is embedded into the output jar under `META-INF/jsmacroscedeps/`.

Port of [grepsedawk/JsMacros-Ruby](https://github.com/grepsedawk/JsMacros-Ruby) (an unofficial 1.21.8 patch of wagyourtail's original `jsmacros-ruby`), adapted to CE's API: split `LanguageExtension` / `LibraryExtension` interfaces, `Core<?, ?>` generic on language/context constructors, non-singleton `profile` access (`ctx.runner.profile` rather than `Core.getInstance().profile`).

## Fixes applied atop the straight port

- Daemon flags + names on the preload thread and the `JavaWrapper` async thread (upstream spawned non-daemon threads that could prevent JVM shutdown).
- Removed a dead `Semaphore` + unused local in `FWrapper.inner_accept` — the semaphore was released but never acquired.
- Extracted a shared `callFn` helper to deduplicate the three near-identical JRuby-call blocks in `FWrapper.RubyMethodWrapper`.

## Script bindings

Bindings exposed as local variables `context` / `event` / `file` (no `$` prefix). This restores the pre-[139c8ce](https://github.com/grepsedawk/JsMacros-Ruby/commit/139c8ce) wagyourtail convention. Legacy scripts that reference bare `context` break under the post-139c8ce global-only form — this restores compatibility.

## Vestigial bits dropped from upstream

- `JRubyConfig` / `useGlobalContext` option — was never registered (the `addOptions` call was commented out) and `JRubyLanguageDefinition` never reads the option.
- `assets/jsmacros/jruby/lang/en_us.json` — its only key was for the unregistered config option.

## Build matrix

Built `:extension:ruby:jar` against each stonecutter version:

- 1.21.5 ✓
- 1.21.8 ✓
- 1.21.10 ✓
- 1.21.11 ✓

Extension has no direct MC-API dependencies, so the same compiled classes are reused across stonecutter versions and will inherit 26.1 compatibility automatically once that lands.

## Testing

In-process ServiceLoader smoke test via `jshell` on JDK 21:

- `ServiceLoader.load(Extension.class, <classloader>)` discovers `JRubyExtension`
- `getExtensionName()` → `"jruby"`, `minCoreVersion=2.0.0`, `maxCoreVersion=2.1.0`
- `getDependencies()` returns the embedded `META-INF/jsmacroscedeps/jruby-complete-9.4.5.0.jar` URL
- Implements both `LanguageExtension` and `LibraryExtension`
- Embedded jruby-complete jar (~33.5 MB) extracts; `org.jruby.embed.ScriptingContainer` resolves from it

Not smoke-tested inside MC's run environment.

## Test plan

- [ ] Drop the built jar into a dev client, confirm the mod loads without an extension registration error
- [ ] Run a minimal `.rb` script via the mod UI and verify it executes
- [ ] Confirm a script using `JavaWrapper.methodToJava` can register a Ruby callback that the host invokes
- [ ] Confirm error-wrapping: deliberately raise inside a Ruby script and check the wrapped stack trace surfaces in logs
