### PR TITLE
Add Minecraft 26.1.2 support

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,9 +17,15 @@ neoForge {
         layout.buildDirectory.file("generated/access-transformer/accesstransformer.cfg")
     )
 
-    parchment {
-        minecraftVersion = commonMod.prop("parchment_minecraft")
-        mappingsVersion = commonMod.prop("parchment_version")
+    val parchment_minecraft = commonMod.prop("parchment_minecraft")
+    val parchment_version = commonMod.prop("parchment_version")
+    // Parchment does not yet ship mappings for 26.1.x; skip the layer when
+    // either property is blank. TODO(26.1): re-enable once parchment publishes.
+    if (parchment_minecraft.isNotBlank() && parchment_version.isNotBlank()) {
+        parchment {
+            minecraftVersion = parchment_minecraft
+            mappingsVersion = parchment_version
+        }
     }
 }
 
@@ -73,19 +79,40 @@ val accessTransformerFile = layout.buildDirectory.file("generated/access-transfo
 val accessWidenerFile = rootProject.file(
     "common/src/main/resources/accesswideners/$minecraft_version-$mod_id.accesswidener"
 )
-val generateAccessTransformer by tasks.registering(Copy::class) {
-    from(accessWidenerFile)
-    into(accessTransformerFile.map { it.asFile.parentFile })
-    rename { "accesstransformer.cfg" }
-    val transformerClass = Class.forName(
-        "dev.kikugie.fletching_table.transformer.Aw2AtFileTransformer"
-    ) as Class<out FilterReader>
-    val argsClass = Class.forName(
-        "dev.kikugie.fletching_table.transformer.Aw2AtFileTransformer\$TransformArgs"
-    )
-    val args = argsClass.getDeclaredConstructor(Path::class.java)
-        .newInstance(accessWidenerFile.toPath())
-    filter(mapOf("args" to args), transformerClass)
+
+// MC 26.1+ ships deobfuscated, so the access widener uses the `official`
+// namespace. Aw2AtFileTransformer only accepts `named`, and 26.1 does not
+// build NeoForge (which is the only consumer of the generated AT file).
+// On 26.1 we still emit an empty AT stub at the canonical path because
+// neoform's createMinecraftArtifacts hashes the file as part of its cache
+// key, and a missing path crashes the task.
+val isDeobfuscatedMc = minecraft_version.startsWith("26.")
+
+val generateAccessTransformer = if (isDeobfuscatedMc) {
+    tasks.register("generateAccessTransformer") {
+        val outFile = accessTransformerFile
+        outputs.file(outFile)
+        doLast {
+            val target = outFile.get().asFile
+            target.parentFile.mkdirs()
+            target.writeText("# Empty AT stub for 26.1 (deobfuscated, NeoForge unsupported).\n")
+        }
+    }
+} else {
+    tasks.register("generateAccessTransformer", Copy::class.java) {
+        from(accessWidenerFile)
+        into(accessTransformerFile.map { it.asFile.parentFile })
+        rename { "accesstransformer.cfg" }
+        val transformerClass = Class.forName(
+            "dev.kikugie.fletching_table.transformer.Aw2AtFileTransformer"
+        ) as Class<out FilterReader>
+        val argsClass = Class.forName(
+            "dev.kikugie.fletching_table.transformer.Aw2AtFileTransformer\$TransformArgs"
+        )
+        val args = argsClass.getDeclaredConstructor(Path::class.java)
+            .newInstance(accessWidenerFile.toPath())
+        filter(mapOf("args" to args), transformerClass)
+    }
 }
 
 tasks.named("createMinecraftArtifacts") {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/access/IScreenInternal.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/access/IScreenInternal.java
@@ -1,11 +1,19 @@
 package com.jsmacrosce.jsmacros.client.access;
 
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import com.jsmacrosce.doclet.DocletIgnore;
 
 @DocletIgnore
 public interface IScreenInternal {
+    //? if >=26.1 {
+    /*void jsmacros_render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta);
+    *///?} else {
     void jsmacros_render(GuiGraphics drawContext, int mouseX, int mouseY, float delta);
+    //?}
 
     void jsmacros_mouseClicked(double mouseX, double mouseY, int button);
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/FakeServerCommandSource.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/FakeServerCommandSource.java
@@ -46,9 +46,15 @@ public class FakeServerCommandSource extends CommandSourceStack {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public Collection<String> getCustomTabSuggestions() {
+        return source.getCustomTabSuggestions();
+    }
+    *///?} else {
     public Collection<String> getCustomTabSugggestions() {
         return source.getCustomTabSugggestions();
     }
+    //?}
 
     @Override
     public Collection<String> getOnlinePlayerNames() {
@@ -92,7 +98,11 @@ public class FakeServerCommandSource extends CommandSourceStack {
 
     @Override
     public void sendSuccess(Supplier<Component> feedbackSupplier, boolean broadcastToOps) {
+        //? if >=26.1 {
+        /*Minecraft.getInstance().player.sendSystemMessage(feedbackSupplier.get());
+        *///?} else {
         Minecraft.getInstance().player.displayClientMessage(feedbackSupplier.get(), false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/RegistryHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/RegistryHelper.java
@@ -6,6 +6,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.commands.arguments.item.ItemParser;
+//? if >=26.1 {
+/*import net.minecraft.commands.arguments.item.ItemInput;
+*///?}
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -100,7 +103,11 @@ public class RegistryHelper {
     @DocletReplaceParams("id: CanOmitNamespace<ItemId>, nbt: string")
     public ItemStackHelper getItemStack(String id, String nbt) throws CommandSyntaxException {
         ItemParser reader = new ItemParser(Objects.requireNonNull(mc.getConnection()).registryAccess());
+        //? if >=26.1 {
+        /*ItemInput itemResult = reader.parse(new StringReader(parseNameSpace(id) + nbt));
+        *///?} else {
         ItemParser.ItemResult itemResult = reader.parse(new StringReader(parseNameSpace(id) + nbt));
+        //?}
         ItemStack stack = new ItemStack(itemResult.item());
         stack.applyComponents(itemResult.components());
         return new CreativeItemStackHelper(stack);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/TextBuilder.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/TextBuilder.java
@@ -8,6 +8,9 @@ import net.minecraft.network.chat.*;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
+//? if >=26.1 {
+/*import net.minecraft.world.item.ItemStackTemplate;
+*///?}
 import com.jsmacrosce.doclet.DocletReplaceParams;
 import com.jsmacrosce.jsmacros.access.CustomClickEvent;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
@@ -152,7 +155,13 @@ public class TextBuilder {
      * @since 1.3.0
      */
     public TextBuilder withShowItemHover(ItemStackHelper item) {
+        //? if >=26.1 {
+        /*if (!item.getRaw().isEmpty()) {
+            self.withStyle(style -> style.withHoverEvent(new HoverEvent.ShowItem(ItemStackTemplate.fromNonEmptyStack(item.getRaw()))));
+        }
+        *///?} else {
         self.withStyle(style -> style.withHoverEvent(new HoverEvent.ShowItem(item.getRaw())));
+        //?}
         return this;
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/inventory/Inventory.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/inventory/Inventory.java
@@ -17,7 +17,6 @@ import net.minecraft.world.entity.animal.horse.AbstractChestedHorse;
 import net.minecraft.world.entity.animal.horse.AbstractHorse;
 //? }
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +31,7 @@ import com.jsmacrosce.jsmacros.client.access.IAbstractMountInventoryScreen;
 import com.jsmacrosce.jsmacros.client.access.IInventory;
 import com.jsmacrosce.jsmacros.client.api.helper.inventory.ItemStackHelper;
 import com.jsmacrosce.jsmacros.client.api.library.impl.FClient;
+import com.jsmacrosce.jsmacros.util.ContainerInputCompat;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -137,8 +137,8 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
      */
     @DocletReplaceParams("slot: int, mousebutton: Trit")
     public Inventory<T> click(int slot, int mousebutton) {
-        ClickType act = mousebutton == 2 ? ClickType.CLONE : ClickType.PICKUP;
-        man.handleInventoryMouseClick(syncId, slot, mousebutton, act, player);
+        int action = mousebutton == 2 ? ContainerInputCompat.CLONE : ContainerInputCompat.PICKUP;
+        ContainerInputCompat.dispatch(man, syncId, slot, mousebutton, action, player);
         return this;
     }
 
@@ -152,11 +152,11 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
     @DocletReplaceParams("slots: int[], mousebutton: Bit")
     public Inventory<T> dragClick(int[] slots, int mousebutton) {
         mousebutton = mousebutton == 0 ? 1 : 5;
-        man.handleInventoryMouseClick(syncId, -999, mousebutton - 1, ClickType.QUICK_CRAFT, player); // start drag click
+        ContainerInputCompat.dispatch(man, syncId, -999, mousebutton - 1, ContainerInputCompat.QUICK_CRAFT, player); // start drag click
         for (int i : slots) {
-            man.handleInventoryMouseClick(syncId, i, mousebutton, ClickType.QUICK_CRAFT, player);
+            ContainerInputCompat.dispatch(man, syncId, i, mousebutton, ContainerInputCompat.QUICK_CRAFT, player);
         }
-        man.handleInventoryMouseClick(syncId, -999, mousebutton + 1, ClickType.QUICK_CRAFT, player);
+        ContainerInputCompat.dispatch(man, syncId, -999, mousebutton + 1, ContainerInputCompat.QUICK_CRAFT, player);
         return this;
     }
 
@@ -165,7 +165,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
      * @since 1.5.0
      */
     public Inventory<T> dropSlot(int slot) {
-        man.handleInventoryMouseClick(syncId, slot, 0, ClickType.THROW, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, 0, ContainerInputCompat.THROW, player);
         return this;
     }
 
@@ -176,7 +176,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
      * @since 1.8.4
      */
     public Inventory<T> dropSlot(int slot, boolean stack) {
-        man.handleInventoryMouseClick(syncId, slot, stack ? 1 : 0, ClickType.THROW, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, stack ? 1 : 0, ContainerInputCompat.THROW, player);
         return this;
     }
 
@@ -337,7 +337,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
     public Inventory<T> closeAndDrop() {
         ItemStack held = handler.getCarried();
         if (!held.isEmpty()) {
-            man.handleInventoryMouseClick(syncId, -999, 0, ClickType.PICKUP, player);
+            ContainerInputCompat.dispatch(man, syncId, -999, 0, ContainerInputCompat.PICKUP, player);
         }
         close();
         return this;
@@ -360,7 +360,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
      * @return
      */
     public Inventory<T> quick(int slot) {
-        man.handleInventoryMouseClick(syncId, slot, 0, ClickType.QUICK_MOVE, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, 0, ContainerInputCompat.QUICK_MOVE, player);
         return this;
     }
 
@@ -393,7 +393,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
                     && slot2.container == hoverSlotInv
                     && AbstractContainerMenu.canItemQuickReplace(slot2, cursorStack, true)) {
                 count += slot2.getItem().getCount();
-                man.handleInventoryMouseClick(syncId, slot2.index, button, ClickType.QUICK_MOVE, player);
+                ContainerInputCompat.dispatch(man, syncId, slot2.index, button, ContainerInputCompat.QUICK_MOVE, player);
             }
         }
         return count;
@@ -436,8 +436,8 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
         if (!getSlot(slot1).isEmpty() || !getSlot(slot2).isEmpty()) {
             throw new Exception("slots must be empty.");
         }
-        man.handleInventoryMouseClick(syncId, slot1, 1, ClickType.PICKUP, player);
-        man.handleInventoryMouseClick(syncId, slot2, 0, ClickType.PICKUP, player);
+        ContainerInputCompat.dispatch(man, syncId, slot1, 1, ContainerInputCompat.PICKUP, player);
+        ContainerInputCompat.dispatch(man, syncId, slot2, 0, ContainerInputCompat.PICKUP, player);
         return this;
     }
 
@@ -448,8 +448,8 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
      * @return
      */
     public Inventory<T> grabAll(int slot) {
-        man.handleInventoryMouseClick(syncId, slot, 0, ClickType.PICKUP, player);
-        man.handleInventoryMouseClick(syncId, slot, 0, ClickType.PICKUP_ALL, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, 0, ContainerInputCompat.PICKUP, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, 0, ContainerInputCompat.PICKUP_ALL, player);
         return this;
     }
 
@@ -469,11 +469,11 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
             return this;
         }
         if (!is1) {
-            man.handleInventoryMouseClick(syncId, slot1, 0, ClickType.PICKUP, player);
+            ContainerInputCompat.dispatch(man, syncId, slot1, 0, ContainerInputCompat.PICKUP, player);
         }
-        man.handleInventoryMouseClick(syncId, slot2, 0, ClickType.PICKUP, player);
+        ContainerInputCompat.dispatch(man, syncId, slot2, 0, ContainerInputCompat.PICKUP, player);
         if (!is2) {
-            man.handleInventoryMouseClick(syncId, slot1, 0, ClickType.PICKUP, player);
+            ContainerInputCompat.dispatch(man, syncId, slot1, 0, ContainerInputCompat.PICKUP, player);
         }
         return this;
     }
@@ -494,7 +494,7 @@ public class Inventory<T extends AbstractContainerScreen<?>> {
                 throw new IllegalArgumentException("hotbarSlot must be between 0 and 8 or 40 for offhand.");
             }
         }
-        man.handleInventoryMouseClick(syncId, slot, hotbarSlot, ClickType.SWAP, player);
+        ContainerInputCompat.dispatch(man, syncId, slot, hotbarSlot, ContainerInputCompat.SWAP, player);
         return this;
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/inventory/LoomInventory.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/inventory/LoomInventory.java
@@ -3,6 +3,9 @@ package com.jsmacrosce.jsmacros.client.api.classes.inventory;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.client.gui.screens.inventory.LoomScreen;
 import net.minecraft.core.Holder;
+//? if >=26.1 {
+/*import net.minecraft.core.HolderSet;
+*///?}
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.BannerPatternTags;
@@ -32,8 +35,13 @@ public class LoomInventory extends Inventory<LoomScreen> {
         if (stack.isEmpty()) {
             return bannerPatternLookup.get(BannerPatternTags.NO_ITEM_REQUIRED).map(ImmutableList::copyOf).orElse(ImmutableList.of());
         } else {
+            //? if >=26.1 {
+            /*HolderSet<BannerPattern> holders = stack.get(DataComponents.PROVIDES_BANNER_PATTERNS);
+            return holders != null ? ImmutableList.copyOf(holders) : List.of();
+            *///?} else {
             TagKey<BannerPattern> tagKey = stack.get(DataComponents.PROVIDES_BANNER_PATTERNS);
             return tagKey != null ? bannerPatternLookup.get(tagKey).map(ImmutableList::copyOf).orElse(ImmutableList.of()) : List.of();
+            //?}
         }
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/Draw2D.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/Draw2D.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.api.classes.render;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.Renderable;
 import org.jetbrains.annotations.Nullable;
 import com.jsmacrosce.doclet.DocletIgnore;
@@ -591,7 +595,11 @@ public class Draw2D implements IDraw2D<Draw2D>, Registrable<Draw2D> {
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     public void render(GuiGraphics drawContext) {
+    //?}
         if (drawContext == null || !visible) {
             return;
         }
@@ -599,7 +607,11 @@ public class Draw2D implements IDraw2D<Draw2D>, Registrable<Draw2D> {
         synchronized (elements) {
             Iterator<RenderElement> iter = getElementsByZIndex();
             while (iter.hasNext()) {
+                //? if >=26.1 {
+                /*iter.next().extractRenderState(drawContext, 0, 0, 0);
+                *///?} else {
                 iter.next().render(drawContext, 0, 0, 0);
+                //?}
             }
         }
     }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/Draw3D.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/Draw3D.java
@@ -4,6 +4,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.world.phys.Vec3;
 import com.jsmacrosce.doclet.DocletIgnore;
 import com.jsmacrosce.jsmacros.api.math.Pos2D;
@@ -709,7 +712,11 @@ public class Draw3D implements Registrable<Draw3D> {
     }
 
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render(PoseStack poseStack, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta) {
+    *///?} else {
     public void render(PoseStack poseStack, MultiBufferSource consumers, float tickDelta) {
+    //?}
         Camera camera = Minecraft.getInstance().gameRenderer.getMainCamera();
         //? if >=1.21.11 {
         /*Vec3 cameraPos = camera.position();
@@ -726,7 +733,11 @@ public class Draw3D implements Registrable<Draw3D> {
             Collections.sort(elements);
 
             for (RenderElement3D<?> element : elements) {
+                //? if >=26.1 {
+                /*element.render(poseStack, consumers, collector, tickDelta);
+                *///?} else {
                 element.render(poseStack, consumers, tickDelta);
+                //?}
             }
         }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/IDraw2D.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/IDraw2D.java
@@ -1,6 +1,10 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render;
 
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import com.jsmacrosce.doclet.DocletIgnore;
 import com.jsmacrosce.doclet.DocletReplaceParams;
 import com.jsmacrosce.jsmacros.client.api.classes.render.components.*;
@@ -768,7 +772,11 @@ public interface IDraw2D<T> {
      * @param drawContext
      */
     @DocletIgnore
+    //? if >=26.1 {
+    /*void render(GuiGraphicsExtractor drawContext);
+    *///?} else {
     void render(GuiGraphics drawContext);
+    //?}
 
     /**
      * @param zIndex

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/ScriptScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/ScriptScreen.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render;
 
 import com.google.common.collect.ImmutableList;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
@@ -33,7 +37,11 @@ public class ScriptScreen extends BaseScreen {
     public boolean shouldPause = true;
     private final int bgStyle;
     @Nullable
+    //? if >=26.1 {
+    /*private MethodWrapper<Pos3D, GuiGraphicsExtractor, Object, ?> onRender;
+    *///?} else {
     private MethodWrapper<Pos3D, GuiGraphics, Object, ?> onRender;
+    //?}
 
     public ScriptScreen(String title, boolean dirt) {
         super(Component.literal(title), null);
@@ -62,30 +70,54 @@ public class ScriptScreen extends BaseScreen {
      * @param onRender pos3d elements are mousex, mousey, tickDelta
      * @since 1.4.0
      */
+    //? if >=26.1 {
+    /*public void setOnRender(@Nullable MethodWrapper<Pos3D, GuiGraphicsExtractor, Object, ?> onRender) {
+    *///?} else {
     public void setOnRender(@Nullable MethodWrapper<Pos3D, GuiGraphics, Object, ?> onRender) {
+    //?}
         this.onRender = onRender;
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         if (drawContext == null) {
             return;
         }
         if (bgStyle == 0) {
+            //? if >=26.1 {
+            /*this.extractMenuBackground(drawContext);
+            *///?} else {
             this.renderMenuBackground(drawContext);
+            //?}
         }
 
         if (drawTitle) {
+            //? if >=26.1 {
+            /*drawContext.centeredText(this.font, this.title, this.width / 2, 20, 0xFFFFFFFF);
+            *///?} else {
             drawContext.drawCenteredString(this.font, this.title, this.width / 2, 20, 0xFFFFFFFF);
+            //?}
         }
 
+        //? if >=26.1 {
+        /*super.extractRenderState(drawContext, mouseX, mouseY, delta);
+        *///?} else {
         super.render(drawContext, mouseX, mouseY, delta);
+        //?}
 
         for (GuiEventListener button : ImmutableList.copyOf(this.children())) {
             if (!(button instanceof Renderable)) {
                 continue;
             }
+            //? if >=26.1 {
+            /*((Renderable) button).extractRenderState(drawContext, mouseX, mouseY, delta);
+            *///?} else {
             ((Renderable) button).render(drawContext, mouseX, mouseY, delta);
+            //?}
         }
 
         ((IScreenInternal) this).jsmacros_render(drawContext, mouseX, mouseY, delta);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Draw2DElement.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Draw2DElement.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2fStack;
 import org.joml.Quaternionf;
@@ -222,7 +226,11 @@ public class Draw2DElement implements RenderElement, Alignable<Draw2DElement> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         Matrix3x2fStack matrices = drawContext.pose();
         matrices.pushMatrix();

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Image.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Image.java
@@ -1,13 +1,26 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+//? if <26.1 {
 import com.mojang.blaze3d.platform.DepthTestFunction;
+//?}
+//? if >=26.1 {
+/*import com.mojang.blaze3d.pipeline.DepthStencilState;
+import com.mojang.blaze3d.platform.CompareOp;
+*///?}
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2fStack;
 import org.joml.Quaternionf;
@@ -44,7 +57,14 @@ public class Image implements RenderElement, Alignable<Image> {
     private static final DepthTestFunction oldEntityTranslucentDepthTestFunction;
     //? }
 
-    //? if >=1.21.11 {
+    //? if >=26.1 {
+    /*private static final RenderPipeline ENTITY_TRANSLUCENT_SEE_THROUGH = RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)
+            .withLocation("pipeline/jsmacrosce/entity_translucent_see_through")
+            .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false))
+            .withCull(false)
+            .build();
+    private static final Map<ResourceLocation, RenderType> ENTITY_TRANSLUCENT_SEE_THROUGH_TYPES = new ConcurrentHashMap<>();
+    *///?} else if >=1.21.11 {
     /*private static final RenderPipeline ENTITY_TRANSLUCENT_SEE_THROUGH = RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)
             .withLocation("pipeline/jsmacrosce/entity_translucent_see_through")
             .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
@@ -342,7 +362,11 @@ public class Image implements RenderElement, Alignable<Image> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         Matrix3x2fStack matrices = drawContext.pose();
         matrices.pushMatrix();
@@ -378,7 +402,11 @@ public class Image implements RenderElement, Alignable<Image> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {
+    *///?} else {
     public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {
+    //?}
         matrixStack.pushPose();
         matrixStack.translate(x, y, 0);
         if (rotateCenter) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Item.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Item.java
@@ -3,8 +3,15 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.util.Mth;
@@ -26,7 +33,9 @@ import java.util.List;
 import net.minecraft.client.renderer.RenderType;
 //?}
 
-//? if >=1.21.10 {
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.item.ItemStackRenderState;
+*///?} else if >=1.21.10 {
 /*import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemTransform;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
@@ -273,13 +282,23 @@ public class Item implements RenderElement, Alignable<Item> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+        extractRenderState(drawContext, mouseX, mouseY, delta, false);
+    }
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
         render(drawContext, mouseX, mouseY, delta, false);
     }
+    //?}
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {
+    *///?} else {
     public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {
+    //?}
         if (item == null) {
             return;
         }
@@ -294,7 +313,18 @@ public class Item implements RenderElement, Alignable<Item> {
             matrixStack.mulPose(new Quaternionf().rotateLocalZ((float) Math.toRadians(rotation)));
         }
 
-        //? if >=1.21.10 {
+        //? if >=26.1 {
+        /*ItemStackRenderState renderState = new ItemStackRenderState();
+        mc.getItemModelResolver().updateForTopItem(renderState, item, ItemDisplayContext.GUI, mc.level, mc.player, 0);
+
+        matrixStack.pushPose();
+        matrixStack.translate(DEFAULT_ITEM_SIZE / 2d, DEFAULT_ITEM_SIZE / 2d, 0);
+        matrixStack.scale(1, -1, 1);
+        matrixStack.scale(DEFAULT_ITEM_SIZE, DEFAULT_ITEM_SIZE, DEFAULT_ITEM_SIZE);
+        matrixStack.scale(1, 1, FLAT_ITEM_DEPTH_SCALE);
+        renderState.submit(matrixStack, collector, light, OverlayTexture.NO_OVERLAY, 0);
+        matrixStack.popPose();
+        *///?} else if >=1.21.10 {
         /*ItemStackRenderState renderState = new ItemStackRenderState();
         mc.getItemModelResolver().updateForTopItem(renderState, item, ItemDisplayContext.GUI, mc.level, mc.player, 0);
 
@@ -366,7 +396,11 @@ public class Item implements RenderElement, Alignable<Item> {
     }
 
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta, boolean is3dRender) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta, boolean is3dRender) {
+    //?}
         if (item == null) {
             return;
         }
@@ -392,7 +426,11 @@ public class Item implements RenderElement, Alignable<Item> {
             //? if >1.21.5 {
             matrices.translate(0, 0, matrices);
             matrices.scale(1, 1, matrices);
+            //? if >=26.1 {
+            /*drawContext.item(item, x, y);
+            *///?} else {
             drawContext.renderItem(item, x, y);
+            //?}
             matrices.scale(1, 1, matrices);
             //?} else {
             /*matrices.translate(0, 0, -0.1f);
@@ -401,7 +439,11 @@ public class Item implements RenderElement, Alignable<Item> {
             matrices.scale(1, 1, 1 / scaleZ);
             *///?}
         } else {
+            //? if >=26.1 {
+            /*drawContext.item(item, x, y);
+            *///?} else {
             drawContext.renderItem(item, x, y);
+            //?}
         }
         if (overlay) {
             if (is3dRender) {
@@ -411,7 +453,11 @@ public class Item implements RenderElement, Alignable<Item> {
                 /*matrices.translate(0, 0, -199.5);
                 *///?}
             }
+            //? if >=26.1 {
+            /*drawContext.itemDecorations(mc.font, item, x, y, ovText);
+            *///?} else {
             drawContext.renderItemDecorations(mc.font, item, x, y, ovText);
+            //?}
         }
 
         //? if >1.21.5 {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Line.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Line.java
@@ -2,10 +2,19 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+//? if <1.21.11 {
 import com.mojang.blaze3d.platform.DepthTestFunction;
+//?}
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2fStack;
@@ -297,7 +306,11 @@ public class Line implements RenderElement, Alignable<Line> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         Matrix3x2fStack matrices = drawContext.pose();
         matrices.pushMatrix();
@@ -337,7 +350,11 @@ public class Line implements RenderElement, Alignable<Line> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {
+    *///?} else {
     public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {
+    //?}
         matrixStack.pushPose();
         matrixStack.translate(x1, y1, 0);
         if (rotateCenter) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Rect.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Rect.java
@@ -1,10 +1,21 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+//? if <26.1 {
 import com.mojang.blaze3d.platform.DepthTestFunction;
+//?}
+//? if >=26.1 {
+/*import com.mojang.blaze3d.pipeline.DepthStencilState;
+import com.mojang.blaze3d.platform.CompareOp;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.util.Mth;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.client.renderer.RenderPipelines;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2fStack;
@@ -36,7 +47,16 @@ public class Rect implements RenderElement, Alignable<Rect> {
     private static final DepthTestFunction oldDebugQuadsDepthTestFunction;
     //? }
 
-    //? if >=1.21.11 {
+    //? if >=26.1 {
+    /*private static final RenderPipeline DEBUG_QUADS_SEE_THROUGH = RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
+            .withLocation("pipeline/jsmacrosce/debug_quads_see_through")
+            .withCull(false)
+            .withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, false))
+            .build();
+    private static final RenderType DEBUG_QUADS_SEE_THROUGH_TYPE = RenderType.create(
+            "jsmacrosce_debug_quads_see_through",
+            RenderSetup.builder(DEBUG_QUADS_SEE_THROUGH).createRenderSetup());
+    *///?} else if >=1.21.11 {
     /*private static final RenderPipeline DEBUG_QUADS_SEE_THROUGH = RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/jsmacrosce/debug_quads_see_through")
             .withCull(false)
@@ -350,7 +370,11 @@ public class Rect implements RenderElement, Alignable<Rect> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         Matrix3x2fStack matrices = drawContext.pose();
         matrices.pushMatrix();
@@ -369,7 +393,11 @@ public class Rect implements RenderElement, Alignable<Rect> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {
+    *///?} else {
     public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {
+    //?}
         matrixStack.pushPose();
         matrixStack.translate(x1, y1, 0);
         if (rotateCenter) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/RenderElement.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/RenderElement.java
@@ -2,9 +2,14 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
+//? if <26.1 {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import org.joml.Matrix3x2fStack;
 import org.joml.Quaternionf;
 import com.jsmacrosce.doclet.DocletIgnore;
@@ -23,7 +28,11 @@ public interface RenderElement extends Renderable {
      * Called by Surface for >1.21.5. Default is a no-op.
      */
     @DocletIgnore
+    //? if >=26.1 {
+    /*default void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {}
+    *///?} else {
     default void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {}
+    //?}
 
     /**
      * Converts a packed lightmap value (as returned by {@code LightTexture.pack()}) to a

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Text.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components/Text.java
@@ -2,8 +2,15 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2fStack;
@@ -258,7 +265,11 @@ public class Text implements RenderElement, Alignable<Text> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         Matrix3x2fStack matrices = drawContext.pose();
         matrices.pushMatrix();
@@ -268,7 +279,11 @@ public class Text implements RenderElement, Alignable<Text> {
         *///?}
 
         setupMatrix(matrices, x, y, (float) scale, rotation, getWidth(), getHeight(), rotateCenter);
+        //? if >=26.1 {
+        /*drawContext.text(mc.font, text, x, y, color, shadow);
+        *///?} else {
         drawContext.drawString(mc.font, text, x, y, color, shadow);
+        //?}
 
         //? if >1.21.5 {
         matrices.popMatrix();
@@ -279,7 +294,11 @@ public class Text implements RenderElement, Alignable<Text> {
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, SubmitNodeCollector collector, float delta) {
+    *///?} else {
     public void render3D(PoseStack matrixStack, MultiBufferSource consumers, int light, boolean seeThrough, float delta) {
+    //?}
         matrixStack.pushPose();
         matrixStack.translate(x, y, 0);
         matrixStack.scale((float) scale, (float) scale, 1);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Box.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Box.java
@@ -1,8 +1,13 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render.components3d;
 
+//? if <1.21.11 {
 import com.mojang.blaze3d.platform.DepthTestFunction;
+//?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.ShapeRenderer;
 import com.jsmacrosce.doclet.DocletIgnore;
@@ -30,6 +35,7 @@ import net.minecraft.client.renderer.RenderType;
  */
 @SuppressWarnings("unused")
 public class Box implements RenderElement3D<Box> {
+    //? if <1.21.11 {
     private static final Field lineDepthTestFunction;
     private static final DepthTestFunction oldlineDepthTestFunction;
     private static final Field boxDepthTestFunction;
@@ -47,6 +53,7 @@ public class Box implements RenderElement3D<Box> {
             throw new RuntimeException(e);
         }
     }
+    //?}
     public Vec3D pos;
     public int color;
     public int fillColor;
@@ -195,7 +202,11 @@ public class Box implements RenderElement3D<Box> {
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render(PoseStack matrixStack, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta) {
+    *///?} else {
     public void render(PoseStack matrixStack, MultiBufferSource consumers, float tickDelta) {
+    //?}
         boolean seeThrough = !this.cull;
         //? if >=1.21.11 {
         /*AABB box = new AABB(pos.getStart().toMojangDoubleVector(), pos.getEnd().toMojangDoubleVector());

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/EntityTraceLine.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/EntityTraceLine.java
@@ -3,6 +3,9 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components3d;
 import com.jsmacrosce.jsmacros.client.util.ColorUtil;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
@@ -63,7 +66,11 @@ public class EntityTraceLine extends TraceLine {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(PoseStack matrixStack, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta) {
+    *///?} else {
     public void render(PoseStack matrixStack, MultiBufferSource consumers, float tickDelta) {
+    //?}
         if (shouldRemove || entity == null || entity.isRemoved() || entity.level() != mc.level) {
             shouldRemove = true;
             dirty = true;
@@ -72,7 +79,11 @@ public class EntityTraceLine extends TraceLine {
 
         Vec3 vec = entity.getPosition(tickDelta);
         setPos(vec.x, vec.y + yOffset, vec.z);
+        //? if >=26.1 {
+        /*super.render(matrixStack, consumers, collector, tickDelta);
+        *///?} else {
         super.render(matrixStack, consumers, tickDelta);
+        //?}
     }
 
     public static class Builder {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Line3D.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Line3D.java
@@ -1,9 +1,14 @@
 package com.jsmacrosce.jsmacros.client.api.classes.render.components3d;
 
+//? if <1.21.11 {
 import com.mojang.blaze3d.platform.DepthTestFunction;
+//?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.client.renderer.RenderPipelines;
 import com.jsmacrosce.doclet.DocletIgnore;
 import com.jsmacrosce.jsmacros.api.math.Pos3D;
@@ -29,6 +34,7 @@ import net.minecraft.client.renderer.RenderType;
  */
 @SuppressWarnings("unused")
 public class Line3D implements RenderElement3D<Line3D> {
+    //? if <1.21.11 {
     private static final Field lineDepthTestFunction;
     private static final DepthTestFunction oldlineDepthTestFunction;
 
@@ -41,6 +47,7 @@ public class Line3D implements RenderElement3D<Line3D> {
             throw new RuntimeException("JS-Macros 3D Rendering failed to reflect into RenderLayer for Line3D", e);
         }
     }
+    //?}
     public Vec3D pos;
     public int color;
     // TODO: deprecate in favor of "alwaysOnTop" (alwaysOnTop is technically the reverse of this)
@@ -189,7 +196,11 @@ public class Line3D implements RenderElement3D<Line3D> {
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render(PoseStack matrixStack, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta) {
+    *///?} else {
     public void render(PoseStack matrixStack, MultiBufferSource consumers, float tickDelta) {
+    //?}
         boolean alwaysOnTop = !this.cull;
         //? if >=1.21.11 {
         /*GizmoProperties gizmo = Gizmos.addGizmo(new LineGizmo(

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/RenderElement3D.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/RenderElement3D.java
@@ -2,13 +2,20 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components3d;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import org.jetbrains.annotations.NotNull;
 import com.jsmacrosce.doclet.DocletIgnore;
 
 public interface RenderElement3D<T extends RenderElement3D<?>> extends Comparable<RenderElement3D<?>> {
 
     @DocletIgnore
+    //? if >=26.1 {
+    /*void render(PoseStack matrices, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta);
+    *///?} else {
     void render(PoseStack matrices, MultiBufferSource consumers, float tickDelta);
+    //?}
 
     @Override
     default int compareTo(@NotNull RenderElement3D o) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Surface.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/Surface.java
@@ -3,10 +3,21 @@ package com.jsmacrosce.jsmacros.client.api.classes.render.components3d;
 import com.jsmacrosce.jsmacros.client.JsMacros;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.multiplayer.ClientLevel;
+//? if >=26.1 {
+/*import net.minecraft.util.LightCoordsUtil;
+*///?} else {
 import net.minecraft.client.renderer.LightTexture;
+//?}
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.phys.Vec3;
@@ -266,7 +277,11 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
      */
     public Surface setLight(int blockLight, int skyLight) {
         this.lightMode = LightMode.CUSTOM;
+        //? if >=26.1 {
+        /*this.customLight = LightCoordsUtil.pack(blockLight, skyLight);
+        *///?} else {
         this.customLight = LightTexture.pack(blockLight, skyLight);
+        //?}
         return this;
     }
 
@@ -312,7 +327,11 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
 
     @Override
     @DocletIgnore
+    //? if >=26.1 {
+    /*public void render(PoseStack matrices, MultiBufferSource consumers, SubmitNodeCollector collector, float partialTicks) {
+    *///?} else {
     public void render(PoseStack matrices, MultiBufferSource consumers, float partialTicks) {
+    //?}
         boolean seeThrough = !this.cull;
         matrices.pushPose();
 
@@ -362,12 +381,22 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
         matrices.scale((float) scale, (float) scale, (float) scale);
 
         synchronized (elements) {
+            //? if >=26.1 {
+            /*renderElements3D(matrices,
+                    consumers,
+                    collector,
+                    partialTicks,
+                    resolveLightValue(renderPos.toRawBlockPos()),
+                    seeThrough,
+                    getElementsByZIndex());
+            *///?} else {
             renderElements3D(matrices,
                     consumers,
                     partialTicks,
                     resolveLightValue(renderPos.toRawBlockPos()),
                     seeThrough,
                     getElementsByZIndex());
+            //?}
         }
         matrices.popPose();
     }
@@ -385,7 +414,11 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
                 if (level == null) yield 0xF000F0;
                 int block = level.getBrightness(LightLayer.BLOCK, blockPos);
                 int sky = level.getBrightness(LightLayer.SKY, blockPos);
+                //? if >=26.1 {
+                /*yield LightCoordsUtil.pack(block, sky);
+                *///?} else {
                 yield LightTexture.pack(block, sky);
+                //?}
             }
         };
     }
@@ -417,19 +450,35 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
         return new Vector3f((float) Math.toDegrees(radianX), (float) Math.toDegrees(radianY), (float) Math.toDegrees(radianZ));
     }
 
+    //? if >=26.1 {
+    /*private void renderElements3D(PoseStack matrices, MultiBufferSource consumers, SubmitNodeCollector collector, float delta, int light, boolean seeThrough, Iterator<RenderElement> iter) {
+    *///?} else {
     private void renderElements3D(PoseStack matrices, MultiBufferSource consumers, float delta, int light, boolean seeThrough, Iterator<RenderElement> iter) {
+    //?}
         while (iter.hasNext()) {
             RenderElement element = iter.next();
             // Render each draw2D element individually so that the cull and renderBack settings are used
             if (element instanceof Draw2DElement draw2DElement) {
+                //? if >=26.1 {
+                /*renderDraw2D3D(matrices, consumers, collector, delta, light, seeThrough, draw2DElement);
+                *///?} else {
                 renderDraw2D3D(matrices, consumers, delta, light, seeThrough, draw2DElement);
+                //?}
             } else {
+                //? if >=26.1 {
+                /*renderElement3D(matrices, consumers, collector, delta, light, seeThrough, element);
+                *///?} else {
                 renderElement3D(matrices, consumers, delta, light, seeThrough, element);
+                //?}
             }
         }
     }
 
+    //? if >=26.1 {
+    /*private void renderDraw2D3D(PoseStack matrices, MultiBufferSource consumers, SubmitNodeCollector collector, float delta, int light, boolean seeThrough, Draw2DElement element) {
+    *///?} else {
     private void renderDraw2D3D(PoseStack matrices, MultiBufferSource consumers, float delta, int light, boolean seeThrough, Draw2DElement element) {
+    //?}
         matrices.pushPose();
         matrices.translate(element.x, element.y, 0);
         matrices.scale(element.scale, element.scale, 1);
@@ -443,24 +492,40 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
         // Don't translate back! Elements are rendered relative to the translated origin.
         Draw2D draw2D = element.getDraw2D();
         synchronized (draw2D.getElements()) {
+            //? if >=26.1 {
+            /*renderElements3D(matrices, consumers, collector, delta, light, seeThrough, draw2D.getElementsByZIndex());
+            *///?} else {
             renderElements3D(matrices, consumers, delta, light, seeThrough, draw2D.getElementsByZIndex());
+            //?}
         }
         matrices.popPose();
     }
 
+    //? if >=26.1 {
+    /*private void renderElement3D(PoseStack matrices, MultiBufferSource consumers, SubmitNodeCollector collector, float delta, int light, boolean seeThrough, RenderElement element) {
+    *///?} else {
     private void renderElement3D(PoseStack matrices, MultiBufferSource consumers, float delta, int light, boolean seeThrough, RenderElement element) {
+    //?}
         matrices.pushPose();
         // The surface's scale transform has already been applied to the matrix stack, so a plain
         // zIndexScale * zIndex translation would be scaled down by `scale` (e.g. 0.01), causing
         // z-fighting.  Divide by scale to keep the world-space z-separation equal to
         // zIndexScale * zIndex regardless of the surface's pixel-to-block scale factor.
         matrices.translate(0, 0, (zIndexScale / scale) * element.getZIndex());
+        //? if >=26.1 {
+        /*element.render3D(matrices, consumers, light, seeThrough, collector, delta);
+        *///?} else {
         element.render3D(matrices, consumers, light, seeThrough, delta);
+        //?}
         matrices.popPose();
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         // This does nothing I guess?
     }
 
@@ -846,7 +911,11 @@ public class Surface extends Draw2D implements RenderElement, RenderElement3D<Su
          */
         public Builder light(int blockLight, int skyLight) {
             this.lightMode = LightMode.CUSTOM;
+            //? if >=26.1 {
+            /*this.customLight = LightCoordsUtil.pack(blockLight, skyLight);
+            *///?} else {
             this.customLight = LightTexture.pack(blockLight, skyLight);
+            //?}
             return this;
         }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/TraceLine.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/render/components3d/TraceLine.java
@@ -4,6 +4,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
+//? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?}
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
 import com.jsmacrosce.jsmacros.api.math.Pos3D;
@@ -155,7 +158,11 @@ public class TraceLine implements RenderElement3D<TraceLine> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(PoseStack matrixStack, MultiBufferSource consumers, SubmitNodeCollector collector, float tickDelta) {
+    *///?} else {
     public void render(PoseStack matrixStack, MultiBufferSource consumers, float tickDelta) {
+    //?}
         Camera camera = Minecraft.getInstance().gameRenderer.getMainCamera();
         //? if >=1.21.11 {
         /*Vec3 cameraPos = camera.position();
@@ -167,7 +174,11 @@ public class TraceLine implements RenderElement3D<TraceLine> {
         Vec3 p1 = cameraPos.add(lookDir);
 
         render.setPos(p1.x, p1.y, p1.z, render.pos.x2, render.pos.y2, render.pos.z2);
+        //? if >=26.1 {
+        /*render.render(matrixStack, consumers, collector, tickDelta);
+        *///?} else {
         render.render(matrixStack, consumers, tickDelta);
+        //?}
     }
 
     /**

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/worldscanner/WorldScanner.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/classes/worldscanner/WorldScanner.java
@@ -25,6 +25,7 @@ import com.jsmacrosce.jsmacros.client.api.helper.world.BlockHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.BlockPosHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.BlockStateHelper;
 import com.jsmacrosce.jsmacros.core.MethodWrapper;
+import com.jsmacrosce.jsmacros.util.ChunkPosUtil;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -101,7 +102,7 @@ public class WorldScanner {
      */
     public List<Pos3D> scanAroundPlayer(int chunkRange) {
         if (mc.player == null) return new ArrayList<>();
-        return scanChunkRange(mc.player.chunkPosition().x, mc.player.chunkPosition().z, chunkRange);
+        return scanChunkRange(ChunkPosUtil.x(mc.player.chunkPosition()), ChunkPosUtil.z(mc.player.chunkPosition()), chunkRange);
     }
 
     /**
@@ -437,16 +438,18 @@ public class WorldScanner {
     }
 
     private Stream<Pos3D> scanChunkInternal(ChunkPos pos, int minY, int maxY) {
-        if (!world.hasChunk(pos.x, pos.z)) {
+        int posX = ChunkPosUtil.x(pos);
+        int posZ = ChunkPosUtil.z(pos);
+        if (!world.hasChunk(posX, posZ)) {
             return Stream.empty();
         }
 
-        long chunkX = (long) pos.x << 4;
-        long chunkZ = (long) pos.z << 4;
+        long chunkX = (long) posX << 4;
+        long chunkZ = (long) posZ << 4;
 
         List<Pos3D> blocks = new ArrayList<>();
 
-        streamChunkSections(world.getChunk(pos.x, pos.z), minY, maxY, (section, yOffset, isInFilter) -> {
+        streamChunkSections(world.getChunk(posX, posZ), minY, maxY, (section, yOffset, isInFilter) -> {
             SimpleBitStorage array = (SimpleBitStorage) ((IPalettedContainer<?>) section.getStates()).jsmacros_getData().jsmacros_getStorage();
             forEach(array, isInFilter, place -> blocks.add(new Pos3D(
                     chunkX + ((place & 255) & 15),
@@ -490,13 +493,15 @@ public class WorldScanner {
         Object2IntOpenHashMap<String> result = new Object2IntOpenHashMap<>();
 
         getBestStream(chunkPositions).flatMap(pos -> {
-            if (!world.getChunkSource().hasChunk(pos.x, pos.z)) {
+            int posX = ChunkPosUtil.x(pos);
+            int posZ = ChunkPosUtil.z(pos);
+            if (!world.getChunkSource().hasChunk(posX, posZ)) {
                 return Stream.empty();
             }
 
             Object2IntOpenHashMap<BlockState> blocks = new Object2IntOpenHashMap<>();
 
-            streamChunkSections(world.getChunk(pos.x, pos.z), (section, yOffset, isInFilter) -> count(section.getStates(), isInFilter, blocks::addTo));
+            streamChunkSections(world.getChunk(posX, posZ), (section, yOffset, isInFilter) -> count(section.getStates(), isInFilter, blocks::addTo));
             return blocks.object2IntEntrySet().stream();
         }).forEach(blockStateEntry -> {
             BlockState state = blockStateEntry.getKey();

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/event/impl/EventRecvMessage.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/event/impl/EventRecvMessage.java
@@ -1,6 +1,10 @@
 package com.jsmacrosce.jsmacros.client.api.event.impl;
 
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessageTag;
+*///?} else {
 import net.minecraft.client.GuiMessageTag;
+//?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MessageSignature;
 import org.jetbrains.annotations.Nullable;

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/CommandContextHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/CommandContextHelper.java
@@ -83,7 +83,11 @@ public class CommandContextHelper extends BaseEvent {
         } else if (arg instanceof ResourceLocation) {
             arg = ((ResourceLocation) arg).toString();
         } else if (arg instanceof ItemInput) {
+            //? if >=26.1 {
+            /*arg = new ItemStackHelper(((ItemInput) arg).createItemStack(1));
+            *///?} else {
             arg = new ItemStackHelper(((ItemInput) arg).createItemStack(1, false));
+            //?}
         } else if (arg instanceof Tag) {
             arg = NBTElementHelper.resolve((Tag) arg);
         } else if (arg instanceof Component) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/InteractionManagerHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/InteractionManagerHelper.java
@@ -24,6 +24,7 @@ import com.jsmacrosce.jsmacros.client.api.helper.world.entity.EntityHelper;
 import com.jsmacrosce.jsmacros.client.api.library.impl.FClient;
 import com.jsmacrosce.jsmacros.core.MethodWrapper;
 import com.jsmacrosce.jsmacros.core.helpers.BaseHelper;
+import com.jsmacrosce.jsmacros.util.InteractionCompat;
 
 import java.util.Locale;
 import java.util.concurrent.Semaphore;
@@ -626,7 +627,7 @@ public class InteractionManagerHelper extends BaseHelper<MultiPlayerGameMode> {
         InteractionHand hand = offHand ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
         boolean joinedMain = JsMacrosClient.clientCore.profile.checkJoinedThreadStack();
         if (joinedMain) {
-            InteractionResult result = base.interact(mc.player, entity.getRaw(), hand);
+            InteractionResult result = InteractionCompat.interact(base, mc.player, entity.getRaw(), hand);
             assert mc.player != null;
             if (result.consumesAction()) {
                 mc.player.swing(hand);
@@ -634,7 +635,7 @@ public class InteractionManagerHelper extends BaseHelper<MultiPlayerGameMode> {
         } else {
             Semaphore wait = new Semaphore(await ? 0 : 1);
             mc.execute(() -> {
-                InteractionResult result = base.interact(mc.player, entity.getRaw(), hand);
+                InteractionResult result = InteractionCompat.interact(base, mc.player, entity.getRaw(), hand);
                 assert mc.player != null;
                 if (result.consumesAction()) {
                     mc.player.swing(hand);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/OptionsHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/OptionsHelper.java
@@ -214,7 +214,11 @@ public class OptionsHelper extends BaseHelper<Options> {
      */
     @DocletReplaceReturn("Difficulty")
     public String getDifficulty() {
+        //? if >=26.1 {
+        /*return mc.level.getDifficulty().getSerializedName();
+        *///?} else {
         return mc.level.getDifficulty().getKey();
+        //?}
     }
 
     /**
@@ -823,7 +827,11 @@ public class OptionsHelper extends BaseHelper<Options> {
          */
         public VideoOptionsHelper setGuiScale(int scale) {
             base.guiScale().set(scale);
+            //? if >=26.1 {
+            /*mc.execute(mc::resizeGui);
+            *///?} else {
             mc.execute(mc::resizeDisplay);
+            //?}
             return this;
         }
 
@@ -2526,7 +2534,11 @@ public class OptionsHelper extends BaseHelper<Options> {
     @Deprecated
     public OptionsHelper setGuiScale(int scale) {
         base.guiScale().set(scale);
+        //? if >=26.1 {
+        /*mc.execute(mc::resizeGui);
+        *///?} else {
         mc.execute(mc::resizeDisplay);
+        //?}
         return this;
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/PacketByteBufferHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/PacketByteBufferHelper.java
@@ -41,6 +41,7 @@ import com.jsmacrosce.jsmacros.client.api.helper.world.DirectionHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.HitResultHelper;
 import com.jsmacrosce.jsmacros.core.MethodWrapper;
 import com.jsmacrosce.jsmacros.core.helpers.BaseHelper;
+import com.jsmacrosce.jsmacros.util.ChunkPosUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -559,7 +560,7 @@ public class PacketByteBufferHelper extends BaseHelper<FriendlyByteBuf> {
      */
     public int[] readChunkPos() {
         ChunkPos pos = base.readChunkPos();
-        return new int[]{pos.x, pos.z};
+        return new int[]{ChunkPosUtil.x(pos), ChunkPosUtil.z(pos)};
     }
 
     /**
@@ -570,7 +571,7 @@ public class PacketByteBufferHelper extends BaseHelper<FriendlyByteBuf> {
     public ChunkHelper readChunkHelper() {
         ChunkPos pos = base.readChunkPos();
         assert Minecraft.getInstance().level != null;
-        ChunkAccess chunk = Minecraft.getInstance().level.getChunk(pos.x, pos.z);
+        ChunkAccess chunk = Minecraft.getInstance().level.getChunk(ChunkPosUtil.x(pos), ChunkPosUtil.z(pos));
         return chunk == null ? null : new ChunkHelper(chunk);
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/StyleHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/StyleHelper.java
@@ -149,7 +149,13 @@ public class StyleHelper extends BaseHelper<Style> {
     public Object getHoverValue() {
         return switch (base.getHoverEvent()) {
             case HoverEvent.ShowText s -> TextHelper.wrap(s.value());
-            case HoverEvent.ShowItem i -> new ItemStackHelper(i.item());
+            case HoverEvent.ShowItem i -> {
+                //? if >=26.1 {
+                /*yield new ItemStackHelper(i.item().create());
+                *///?} else {
+                yield new ItemStackHelper(i.item());
+                //?}
+            }
             case HoverEvent.ShowEntity e -> e.entity().getTooltipLines().stream().map(TextHelper::wrap).collect(Collectors.toList());
             case null, default -> null;
         };

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/inventory/ItemHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/inventory/ItemHelper.java
@@ -6,6 +6,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.commands.arguments.item.ItemParser;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+//? if >=26.1 {
+/*import net.minecraft.commands.arguments.item.ItemInput;
+import net.minecraft.network.chat.Component;
+*///?}
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.item.*;
 import org.jetbrains.annotations.Nullable;
@@ -131,7 +135,11 @@ public class ItemHelper extends BaseHelper<Item> {
      * @since 1.8.4
      */
     public boolean hasRecipeRemainder() {
+        //? if >=26.1 {
+        /*return base.getCraftingRemainder() != null;
+        *///?} else {
         return !base.getCraftingRemainder().isEmpty();
+        //?}
     }
 
     /**
@@ -140,7 +148,12 @@ public class ItemHelper extends BaseHelper<Item> {
      */
     @Nullable
     public ItemStackHelper getRecipeRemainder() {
+        //? if >=26.1 {
+        /*var remainder = base.getCraftingRemainder();
+        return remainder == null ? null : new ItemStackHelper(remainder.create());
+        *///?} else {
         return new ItemStackHelper(base.getCraftingRemainder());
+        //?}
     }
 
     /**
@@ -162,7 +175,11 @@ public class ItemHelper extends BaseHelper<Item> {
      * @since 1.8.4
      */
     public String getName() {
+        //? if >=26.1 {
+        /*return Component.translatable(base.getDescriptionId()).getString();
+        *///?} else {
         return base.getName().getString();
+        //?}
     }
 
     /**
@@ -201,7 +218,11 @@ public class ItemHelper extends BaseHelper<Item> {
         if (types == null) {
             return false;
         }
+        //? if >=26.1 {
+        /*return types.types().unwrap().left().map(t -> t.equals(DamageTypeTags.IS_FIRE)).orElse(false);
+        *///?} else {
         return types.types() == DamageTypeTags.IS_FIRE;
+        //?}
     }
 
     /**
@@ -265,8 +286,13 @@ public class ItemHelper extends BaseHelper<Item> {
      */
     public ItemStackHelper getStackWithNbt(String nbt) throws CommandSyntaxException {
         ItemParser reader = new ItemParser(Objects.requireNonNull(mc.getConnection()).registryAccess());
+        //? if >=26.1 {
+        /*ItemInput itemInput = reader.parse(new StringReader(getId() + nbt));
+        return new ItemStackHelper(itemInput.createItemStack(1));
+        *///?} else {
         ItemParser.ItemResult itemResult = reader.parse(new StringReader(getId() + nbt));
         return new ItemStackHelper(new ItemStack(itemResult.item()));
+        //?}
     }
 
     @Override

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/inventory/ItemStackHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/inventory/ItemStackHelper.java
@@ -9,6 +9,9 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.Tag;
+//? if >=26.1 {
+/*import net.minecraft.network.chat.Component;
+*///?}
 import net.minecraft.network.chat.Style;
 import net.minecraft.tags.EnchantmentTags;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -266,7 +269,11 @@ public class ItemStackHelper extends BaseHelper<ItemStack> {
      * @since 1.2.0
      */
     public TextHelper getDefaultName() {
+        //? if >=26.1 {
+        /*return TextHelper.wrap(Component.translatable(base.getItem().getDescriptionId()));
+        *///?} else {
         return TextHelper.wrap(base.getItem().getName());
+        //?}
     }
 
     /**
@@ -335,7 +342,11 @@ public class ItemStackHelper extends BaseHelper<ItemStack> {
      */
     @DocletReplaceReturn("JavaList<ItemTag>")
     public List<String> getTags() {
+        //? if >=26.1 {
+        /*return base.typeHolder().tags().map(t -> t.location().toString()).collect(Collectors.toList());
+        *///?} else {
         return base.getItemHolder().tags().map(t -> t.location().toString()).collect(Collectors.toList());
+        //?}
     }
 
     /**

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/ChatHudLineHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/ChatHudLineHelper.java
@@ -1,6 +1,10 @@
 package com.jsmacrosce.jsmacros.client.api.helper.screen;
 
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessage;
+*///?} else {
 import net.minecraft.client.GuiMessage;
+//?}
 import net.minecraft.client.gui.components.ChatComponent;
 import com.jsmacrosce.jsmacros.client.api.helper.TextHelper;
 import com.jsmacrosce.jsmacros.core.helpers.BaseHelper;

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/ClickableWidgetHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/ClickableWidgetHelper.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.api.helper.screen;
 
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
@@ -272,8 +276,16 @@ public class ClickableWidgetHelper<B extends ClickableWidgetHelper<B, T>, T exte
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*base.extractRenderState(drawContext, mouseX, mouseY, delta);
+        *///?} else {
         base.render(drawContext, mouseX, mouseY, delta);
+        //?}
         if (base.isMouseOver(mouseX, mouseY) && !tooltips.isEmpty()) {
             //? if >1.21.5 {
             drawContext.setComponentTooltipForNextFrame(mc.font, tooltips, mouseX, mouseY);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/TextFieldWidgetHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/screen/TextFieldWidgetHelper.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.components.EditBox;
 import org.jetbrains.annotations.Nullable;
+import com.jsmacrosce.jsmacros.client.JsMacros;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
 import com.jsmacrosce.jsmacros.client.api.classes.render.IScreen;
 import com.jsmacrosce.jsmacros.client.mixin.access.MixinTextFieldWidget;
@@ -11,6 +12,7 @@ import com.jsmacrosce.jsmacros.core.MethodWrapper;
 
 import java.util.Objects;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -148,13 +150,26 @@ public class TextFieldWidgetHelper extends ClickableWidgetHelper<TextFieldWidget
         return this;
     }
 
+    // EditBox.setFilter(Predicate<String>) was removed in 26.1 with no replacement — the public API
+    // lost user-configurable input rejection (only internal StringUtil.filterText survives, and
+    // TextFormatter is visual-only). These setters warn once per JVM on 26.1+ rather than silently
+    // no-op, so macros noticed the behavior change instead of mysteriously failing.
+    private static final AtomicBoolean SET_TEXT_PREDICATE_WARNED = new AtomicBoolean();
+    private static final AtomicBoolean RESET_TEXT_PREDICATE_WARNED = new AtomicBoolean();
+
     /**
      * @param predicate the text filter
      * @return self for chaining.
      * @since 1.8.4
      */
     public TextFieldWidgetHelper setTextPredicate(MethodWrapper<String, ?, ?, ?> predicate) {
+        //? if <26.1 {
         base.setFilter(predicate);
+        //?} else {
+        /*if (SET_TEXT_PREDICATE_WARNED.compareAndSet(false, true)) {
+            JsMacros.LOGGER.warn("TextFieldWidgetHelper.setTextPredicate is a no-op on Minecraft 26.1+: EditBox.setFilter was removed upstream with no replacement.");
+        }
+        *///?}
         return this;
     }
 
@@ -163,7 +178,13 @@ public class TextFieldWidgetHelper extends ClickableWidgetHelper<TextFieldWidget
      * @since 1.8.4
      */
     public TextFieldWidgetHelper resetTextPredicate() {
+        //? if <26.1 {
         base.setFilter(Objects::nonNull);
+        //?} else {
+        /*if (RESET_TEXT_PREDICATE_WARNED.compareAndSet(false, true)) {
+            JsMacros.LOGGER.warn("TextFieldWidgetHelper.resetTextPredicate is a no-op on Minecraft 26.1+: EditBox.setFilter was removed upstream with no replacement.");
+        }
+        *///?}
         return this;
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/BlockDataHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/BlockDataHelper.java
@@ -122,9 +122,13 @@ public class BlockDataHelper extends BaseHelper<BlockState> {
      */
     public Map<String, String> getBlockState() {
         Map<String, String> map = new HashMap<>();
+        //? if >=26.1 {
+        /*base.getValues().forEach(v -> map.put(v.property().getName(), Util.getPropertyName(v.property(), v.value())));
+        *///?} else {
         for (Entry<Property<?>, Comparable<?>> e : base.getValues().entrySet()) {
             map.put(e.getKey().getName(), Util.getPropertyName(e.getKey(), e.getValue()));
         }
+        //?}
         return map;
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/ChunkHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/ChunkHelper.java
@@ -15,6 +15,7 @@ import com.jsmacrosce.doclet.DocletReplaceReturn;
 import com.jsmacrosce.jsmacros.client.api.helper.world.entity.EntityHelper;
 import com.jsmacrosce.jsmacros.core.MethodWrapper;
 import com.jsmacrosce.jsmacros.core.helpers.BaseHelper;
+import com.jsmacrosce.jsmacros.util.ChunkPosUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -93,7 +94,7 @@ public class ChunkHelper extends BaseHelper<ChunkAccess> {
      * @since 1.8.4
      */
     public int getChunkX() {
-        return base.getPos().x;
+        return ChunkPosUtil.x(base.getPos());
     }
 
     /**
@@ -101,7 +102,7 @@ public class ChunkHelper extends BaseHelper<ChunkAccess> {
      * @since 1.8.4
      */
     public int getChunkZ() {
-        return base.getPos().z;
+        return ChunkPosUtil.z(base.getPos());
     }
 
     /**

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/StateHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/StateHelper.java
@@ -30,7 +30,11 @@ public abstract class StateHelper<U extends StateHolder<?, ?>> extends BaseHelpe
      * @since 1.8.4
      */
     public Map<String, String> toMap() {
+        //? if >=26.1 {
+        /*return base.getValues().collect(Collectors.toMap(v -> v.property().getName(), v -> Util.getPropertyName(v.property(), v.value())));
+        *///?} else {
         return base.getValues().entrySet().stream().collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> Util.getPropertyName(entry.getKey(), entry.getValue())));
+        //?}
     }
 
     public <T extends Comparable<?>> StateHelper<U> with(String property, String value) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/entity/ClientPlayerEntityHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/entity/ClientPlayerEntityHelper.java
@@ -23,6 +23,9 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
+//? if >=26.1 {
+/*import net.minecraft.network.chat.Component;
+*///?}
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -38,6 +41,7 @@ import com.jsmacrosce.jsmacros.client.api.helper.AdvancementManagerHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.inventory.ItemStackHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.BlockPosHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.BlockStateHelper;
+import com.jsmacrosce.jsmacros.util.InteractionCompat;
 
 import java.util.List;
 import java.util.Locale;
@@ -482,7 +486,7 @@ public class ClientPlayerEntityHelper<T extends LocalPlayer> extends PlayerEntit
         InteractionHand hand = offHand ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
         boolean joinedMain = JsMacrosClient.clientCore.profile.checkJoinedThreadStack();
         if (joinedMain) {
-            InteractionResult result = mc.gameMode.interact(mc.player, entity.getRaw(), hand);
+            InteractionResult result = InteractionCompat.interact(mc.gameMode, mc.player, entity.getRaw(), hand);
             assert mc.player != null;
             if (result.consumesAction()) {
                 mc.player.swing(hand);
@@ -490,7 +494,7 @@ public class ClientPlayerEntityHelper<T extends LocalPlayer> extends PlayerEntit
         } else {
             Semaphore wait = new Semaphore(await ? 0 : 1);
             mc.execute(() -> {
-                InteractionResult result = mc.gameMode.interact(mc.player, entity.getRaw(), hand);
+                InteractionResult result = InteractionCompat.interact(mc.gameMode, mc.player, entity.getRaw(), hand);
                 assert mc.player != null;
                 if (result.consumesAction()) {
                     mc.player.swing(hand);
@@ -733,7 +737,11 @@ public class ClientPlayerEntityHelper<T extends LocalPlayer> extends PlayerEntit
     public Map<String, Integer> getItemCooldownsRemainingTicks() {
         int tick = ((IItemCooldownManager) base.getCooldowns()).jsmacros_getManagerTicks();
         Map<Item, IItemCooldownEntry> map = ((IItemCooldownManager) base.getCooldowns()).jsmacros_getCooldownItems();
+        //? if >=26.1 {
+        /*return map.entrySet().stream().collect(Collectors.toMap(e -> Component.translatable(e.getKey().getDescriptionId()).getString(), e -> e.getValue().jsmacros_getEndTick() - tick));
+        *///?} else {
         return map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName().getString(), e -> e.getValue().jsmacros_getEndTick() - tick));
+        //?}
     }
 
     /**
@@ -760,7 +768,11 @@ public class ClientPlayerEntityHelper<T extends LocalPlayer> extends PlayerEntit
     public Map<String, Integer> getTicksSinceCooldownsStart() {
         int tick = ((IItemCooldownManager) base.getCooldowns()).jsmacros_getManagerTicks();
         Map<Item, IItemCooldownEntry> map = ((IItemCooldownManager) base.getCooldowns()).jsmacros_getCooldownItems();
+        //? if >=26.1 {
+        /*return map.entrySet().stream().collect(Collectors.toMap(e -> Component.translatable(e.getKey().getDescriptionId()).getString(), e -> e.getValue().jsmacros_getStartTick() - tick));
+        *///?} else {
         return map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName().getString(), e -> e.getValue().jsmacros_getStartTick() - tick));
+        //?}
     }
 
     /**

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/entity/EntityHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/helper/world/entity/EntityHelper.java
@@ -69,6 +69,7 @@ import com.jsmacrosce.jsmacros.client.api.helper.world.entity.specialized.vehicl
 import com.jsmacrosce.jsmacros.client.api.helper.world.entity.specialized.vehicle.FurnaceMinecartEntityHelper;
 import com.jsmacrosce.jsmacros.client.api.helper.world.entity.specialized.vehicle.TntMinecartEntityHelper;
 import com.jsmacrosce.jsmacros.core.helpers.BaseHelper;
+import com.jsmacrosce.jsmacros.util.ChunkPosUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -183,7 +184,7 @@ public class EntityHelper<T extends Entity> extends BaseHelper<T> {
      * @since 1.6.5
      */
     public Pos2D getChunkPos() {
-        return new Pos2D(base.chunkPosition().x, base.chunkPosition().z);
+        return new Pos2D(ChunkPosUtil.x(base.chunkPosition()), ChunkPosUtil.z(base.chunkPosition()));
     }
 
     /**

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/library/impl/FClient.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/library/impl/FClient.java
@@ -484,7 +484,12 @@ public class FClient extends PerExecLibrary {
      */
     public void grabMouse() {
         mc.options.pauseOnLostFocus = false;
+        // Minecraft.setWindowActive(boolean) was removed in 26.1 with no replacement — focus
+        // state is now owned by Window via GLFW callbacks. The setter was belt-and-suspenders
+        // for focus regain; mouseHandler.grabMouse + pauseOnLostFocus=false carry the core behavior.
+        //? if <26.1 {
         mc.setWindowActive(true);
+        //?}
         mc.mouseHandler.grabMouse();
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/api/library/impl/FWorld.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/api/library/impl/FWorld.java
@@ -644,7 +644,11 @@ public class FWorld extends BaseLibrary {
     public long getTimeOfDay() {
         ClientLevel world = mc.level;
         if (world == null) return -1;
+        //? if >=26.1 {
+        /*return world.getDefaultClockTime();
+        *///?} else {
         return world.getDayTime();
+        //?}
     }
 
     /**
@@ -743,9 +747,11 @@ public class FWorld extends BaseLibrary {
     public int getMoonPhase() {
         ClientLevel world = mc.level;
         if (world == null) return -1;
-        //? if >=1.21.11 {
+        //? if >=26.1 {
+        /*return (int) (world.getDefaultClockTime() / 24000L % 8L + 8L) % 8;
+        *///?} else if >=1.21.11 {
         /*return (int) (world.getDayTime() / 24000L % 8L + 8L) % 8;
-        *///? } else {
+        *///?} else {
         return world.getMoonPhase();
         //? }
     }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/MacroContainer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/MacroContainer.java
@@ -4,7 +4,11 @@ import com.mojang.blaze3d.opengl.GlStateManager;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.renderer.RenderPipelines;
 //? if <=1.21.5 {
 /*import net.minecraft.client.renderer.RenderType;
@@ -213,7 +217,11 @@ public class MacroContainer extends MultiElementContainer<MacroScreen> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         BaseEventRegistry reg = JsMacrosClient.clientCore.eventRegistry;
         if (macro.triggerType == ScriptTrigger.TriggerType.EVENT && reg.events.contains(macro.event)) {
             joinedBtn.active = reg.joinableEvents.contains(macro.event);
@@ -326,7 +334,11 @@ public class MacroContainer extends MultiElementContainer<MacroScreen> {
             // overlay
             if (keyBtn.hovering && keyBtn.cantRenderAllText()) {
                 drawContext.fill(mouseX - 2, mouseY - textRenderer.lineHeight - 3, mouseX + textRenderer.width(keyBtn.getMessage()) + 2, mouseY, 0xFF000000);
+                //? if >=26.1 {
+                /*drawContext.text(textRenderer, keyBtn.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                *///?} else {
                 drawContext.drawString(textRenderer, keyBtn.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                //?}
             }
             if (fileBtn.hovering && fileBtn.cantRenderAllText()) {
                 List<FormattedCharSequence> lines = textRenderer.split(fileBtn.getMessage(), this.x + this.width - mouseX);
@@ -335,7 +347,11 @@ public class MacroContainer extends MultiElementContainer<MacroScreen> {
                 drawContext.fill(mouseX - 2, top - 1, mouseX + width + 2, mouseY, 0xFF000000);
                 for (int i = 0; i < lines.size(); ++i) {
                     int wi = textRenderer.width(lines.get(i)) / 2;
+                    //? if >=26.1 {
+                    /*drawContext.text(textRenderer, lines.get(i), mouseX + width / 2 - wi, top + textRenderer.lineHeight * i, 0xFFFFFFFF, false);
+                    *///?} else {
                     drawContext.drawString(textRenderer, lines.get(i), mouseX + width / 2 - wi, top + textRenderer.lineHeight * i, 0xFFFFFFFF, false);
+                    //?}
                 }
             }
         }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/MacroListTopbar.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/MacroListTopbar.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.containers;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
 import com.jsmacrosce.jsmacros.client.config.ClientConfigV2;
@@ -61,7 +65,11 @@ public class MacroListTopbar extends MultiElementContainer<MacroScreen> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         drawContext.fill(x, y, x + width, y + 1, 0xFFFFFFFF);
         drawContext.fill(x, y + height - 2, x + width, y + height - 1, 0xFFFFFFFF);
         drawContext.fill(x, y + height - 1, x + width, y + height, 0xFF7F7F7F);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/RunningContextContainer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/RunningContextContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.containers;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import com.jsmacrosce.jsmacros.client.JsMacros;
@@ -42,15 +46,27 @@ public class RunningContextContainer extends MultiElementContainer<CancelScreen>
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         try {
             if (t != null) {
                 if (t.isContextClosed()) {
                     JsMacros.LOGGER.warn("Closed context {} was still in list", t.getMainThread().getName());
                     parent.removeContainer(this);
                 } else if (this.visible) {
+                    //? if >=26.1 {
+                    /*drawContext.centeredText(textRenderer, textRenderer.plainSubstrByWidth(service ? ((EventService) t.getTriggeringEvent()).serviceName : t.getMainThread().getName(), width - 105 - height), x + (width - 105 - height) / 2 + height + 4, y + 2, 0xFFFFFFFF);
+                    *///?} else {
                     drawContext.drawCenteredString(textRenderer, textRenderer.plainSubstrByWidth(service ? ((EventService) t.getTriggeringEvent()).serviceName : t.getMainThread().getName(), width - 105 - height), x + (width - 105 - height) / 2 + height + 4, y + 2, 0xFFFFFFFF);
+                    //?}
+                    //? if >=26.1 {
+                    /*drawContext.centeredText(textRenderer, textRenderer.plainSubstrByWidth(DurationFormatUtils.formatDurationHMS(System.currentTimeMillis() - t.startTime), 100), x + width - 50 + height, y + 2, 0xFFFFFFFF);
+                    *///?} else {
                     drawContext.drawCenteredString(textRenderer, textRenderer.plainSubstrByWidth(DurationFormatUtils.formatDurationHMS(System.currentTimeMillis() - t.startTime), 100), x + width - 50 + height, y + 2, 0xFFFFFFFF);
+                    //?}
                     drawContext.fill(x + width - 101, y, x + width - 100, y + height, 0xFFFFFFFF);
                     drawContext.fill(x + height, y, x + height + 1, y + height, 0xFFFFFFFF);
                     // border

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/ServiceContainer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/ServiceContainer.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.gui.containers;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
 import com.jsmacrosce.jsmacros.client.gui.overlays.TextOverlay;
@@ -113,7 +117,11 @@ public class ServiceContainer extends MultiElementContainer<MacroScreen> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         int w = width - 12;
         //seperate
         drawContext.fill(x + w * 2 / 12, y + 1, x + w * 2 / 12 + 1, y + height - 1, 0xFFFFFFFF);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/ServiceListTopbar.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/containers/ServiceListTopbar.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.containers;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
 import com.jsmacrosce.jsmacros.client.config.ClientConfigV2;
@@ -57,7 +61,11 @@ public class ServiceListTopbar extends MultiElementContainer<ServiceScreen> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         drawContext.fill(x, y, x + width, y + 1, 0xFFFFFFFF);
         drawContext.fill(x, y + height - 2, x + width, y + height - 1, 0xFFFFFFFF);
         drawContext.fill(x, y + height - 1, x + width, y + height, 0xFF7F7F7F);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/AboutOverlay.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/AboutOverlay.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
 import com.jsmacrosce.wagyourgui.elements.Button;
@@ -46,18 +50,34 @@ public class AboutOverlay extends OverlayContainer {
         this.vcenter = ((height - 12) - (lines * textRenderer.lineHeight)) / 2;
     }
 
+    //? if >=26.1 {
+    /*protected void renderMessage(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     protected void renderMessage(GuiGraphics drawContext) {
+    //?}
         for (int i = 0; i < lines; ++i) {
             int w = textRenderer.width(text.get(i));
+            //? if >=26.1 {
+            /*drawContext.text(textRenderer, text.get(i), (int) (x + width / 2F - w / 2F), y + 2 + vcenter + (i * textRenderer.lineHeight), 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawString(textRenderer, text.get(i), (int) (x + width / 2F - w / 2F), y + 2 + vcenter + (i * textRenderer.lineHeight), 0xFFFFFFFF, false);
+            //?}
         }
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
 
+        //? if >=26.1 {
+        /*drawContext.textWithWordWrap(textRenderer, Component.translatable("jsmacrosce.about"), x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawWordWrap(textRenderer, Component.translatable("jsmacrosce.about"), x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        //?}
         renderMessage(drawContext);
 
         drawContext.fill(x + 2, y + 12, x + width - 2, y + 13, 0xFFFFFFFF);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/EventChooser.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/EventChooser.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.gui.overlays;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
@@ -108,10 +112,18 @@ public class EventChooser extends OverlayContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
 
+        //? if >=26.1 {
+        /*drawContext.textWithWordWrap(textRenderer, eventText, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawWordWrap(textRenderer, eventText, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        //?}
 
         drawContext.fill(x + 2, y + 12, x + width - 2, y + 13, 0xFFFFFFFF);
         drawContext.fill(x + 2, y + height - 15, x + width - 2, y + height - 14, 0xFFFFFFFF);
@@ -129,7 +141,11 @@ public class EventChooser extends OverlayContainer {
 
                 // fill
                 drawContext.fill(mouseX - 2, mouseY - textRenderer.lineHeight - 3, mouseX + width + 2, mouseY, 0xFF000000);
+                //? if >=26.1 {
+                /*drawContext.text(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                *///?} else {
                 drawContext.drawString(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                //?}
             }
         }
     }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/FileChooser.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/FileChooser.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.gui.overlays;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
@@ -211,10 +215,18 @@ public class FileChooser extends OverlayContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
 
+        //? if >=26.1 {
+        /*drawContext.textWithWordWrap(textRenderer, this.dirname, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawWordWrap(textRenderer, this.dirname, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        //?}
 
         drawContext.fill(x + 2, y + 12, x + width - 2, y + 13, 0xFFFFFFFF);
         drawContext.fill(x + 2, y + height - 15, x + width - 2, y + height - 14, 0xFFFFFFFF);
@@ -232,7 +244,11 @@ public class FileChooser extends OverlayContainer {
 
                 // fill
                 drawContext.fill(mouseX - 2, mouseY - textRenderer.lineHeight - 3, mouseX + width + 2, mouseY, 0xFF000000);
+                //? if >=26.1 {
+                /*drawContext.text(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                *///?} else {
                 drawContext.drawString(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                //?}
             }
         }
     }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/TextOverlay.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/overlays/TextOverlay.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.wagyourgui.elements.Button;
 import com.jsmacrosce.wagyourgui.overlays.IOverlayParent;
@@ -26,10 +30,18 @@ public class TextOverlay extends OverlayContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
         int x = this.centered ? Math.max(this.x + 3, this.x + 3 + (this.width - 6) / 2 - this.textRenderer.width(this.text) / 2) : this.x + 3;
+        //? if >=26.1 {
+        /*drawContext.textWithWordWrap(textRenderer, this.text, x, this.y + 5, width - 6, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawWordWrap(textRenderer, this.text, x, this.y + 5, width - 6, 0xFFFFFFFF, false);
+        //?}
         super.render(drawContext, mouseX, mouseY, delta);
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/CancelScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/CancelScreen.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.screens;
 
 import com.google.common.collect.ImmutableList;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -98,12 +102,20 @@ public class CancelScreen extends BaseScreen {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         if (drawContext == null) {
             return;
         }
 
+        //? if >=26.1 {
+        /*super.extractRenderState(drawContext, mouseX, mouseY, delta);
+        *///?} else {
         super.render(drawContext, mouseX, mouseY, delta);
+        //?}
 
         List<BaseScriptContext<?>> tl = new ArrayList<>(JsMacrosClient.clientCore.getContexts());
 
@@ -123,7 +135,11 @@ public class CancelScreen extends BaseScreen {
             if (!(b instanceof Renderable)) {
                 continue;
             }
+            //? if >=26.1 {
+            /*((Renderable) b).extractRenderState(drawContext, mouseX, mouseY, delta);
+            *///?} else {
             ((Renderable) b).render(drawContext, mouseX, mouseY, delta);
+            //?}
         }
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/EditorScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/EditorScreen.java
@@ -4,7 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
@@ -750,17 +754,33 @@ public class EditorScreen extends BaseScreen {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         assert minecraft != null;
 
         //? if <=1.21.5 {
         /*this.renderBackground(drawContext, mouseX, mouseY, delta);
         *///?}
 
+        //? if >=26.1 {
+        /*drawContext.text(font, fileName, 2, 2, 0xFFFFFFFF);
+        *///?} else {
         drawContext.drawString(font, fileName, 2, 2, 0xFFFFFFFF);
+        //?}
 
+        //? if >=26.1 {
+        /*drawContext.text(font, String.format("%d ms", (int) textRenderTime), 2, height - 10, 0xFFFFFFFF);
+        *///?} else {
         drawContext.drawString(font, String.format("%d ms", (int) textRenderTime), 2, height - 10, 0xFFFFFFFF);
+        //?}
+        //? if >=26.1 {
+        /*drawContext.text(font, lineCol, (int) (width - font.width(lineCol) - (width - 10) / 4F - 2), height - 10, 0xFFFFFFFF);
+        *///?} else {
         drawContext.drawString(font, lineCol, (int) (width - font.width(lineCol) - (width - 10) / 4F - 2), height - 10, 0xFFFFFFFF);
+        //?}
 
         drawContext.fill(0, 12, width - 10, height - 12, 0xFF2B2B2B);
         drawContext.fill(lineNumWidth, 12, lineNumWidth + 1, height - 12, 0xFF707070);
@@ -788,14 +808,26 @@ public class EditorScreen extends BaseScreen {
                 drawContext.fill(lineNumWidth + 1, y + add + i * lineSpread, lineNumWidth + 2 + cursor.endCol, y + add + (i + 1) * lineSpread, 0xFF33508F);
             }
             Component lineNum = Component.literal(String.format("%d.", j + 1)).setStyle(lineNumStyle);
+            //? if >=26.1 {
+            /*drawContext.text(minecraft.font, lineNum, lineNumWidth - 2 - minecraft.font.width(lineNum), y + add + i * lineSpread, 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawString(minecraft.font, lineNum, lineNumWidth - 2 - minecraft.font.width(lineNum), y + add + i * lineSpread, 0xFFFFFFFF, false);
+            //?}
+            //? if >=26.1 {
+            /*drawContext.text(minecraft.font, trim(renderedText[j]), lineNumWidth + 2, y + add + i * lineSpread, 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawString(minecraft.font, trim(renderedText[j]), lineNumWidth + 2, y + add + i * lineSpread, 0xFFFFFFFF, false);
+            //?}
         }
         drawContext.disableScissor();
 
         for (GuiEventListener b : ImmutableList.copyOf(this.children())) {
             if (b instanceof Renderable) {
+                //? if >=26.1 {
+                /*((Renderable) b).extractRenderState(drawContext, mouseX, mouseY, delta);
+                *///?} else {
                 ((Renderable) b).render(drawContext, mouseX, mouseY, delta);
+                //?}
             }
         }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/MacroScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/screens/MacroScreen.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.screens;
 
 import com.google.common.collect.ImmutableList;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -199,7 +203,11 @@ public class MacroScreen extends BaseScreen {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         if (drawContext == null) {
             return;
         }
@@ -212,7 +220,11 @@ public class MacroScreen extends BaseScreen {
 
         for (GuiEventListener b : ImmutableList.copyOf(this.children())) {
             if (b instanceof Renderable) {
+                //? if >=26.1 {
+                /*((Renderable) b).extractRenderState(drawContext, mouseX, mouseY, delta);
+                *///?} else {
                 ((Renderable) b).render(drawContext, mouseX, mouseY, delta);
+                //?}
             }
         }
 
@@ -224,7 +236,11 @@ public class MacroScreen extends BaseScreen {
         drawContext.fill(this.width / 6 * 2, 0, this.width / 6 * 2 + 2, 20, 0xFFFFFFFF);
         drawContext.fill(this.width / 6 * 3 + 1, 0, this.width / 6 * 3 + 3, 20, 0xFFFFFFFF);
         drawContext.fill(0, 20, width, 22, 0xFFFFFFFF);
+        //? if >=26.1 {
+        /*drawContext.centeredText(this.font, JsMacrosClient.clientCore.profile.getCurrentProfileName(), this.width * 8 / 12, 5, 0xFF7F7F7F);
+        *///?} else {
         drawContext.drawCenteredString(this.font, JsMacrosClient.clientCore.profile.getCurrentProfileName(), this.width * 8 / 12, 5, 0xFF7F7F7F);
+        //?}
 
         if (overlay != null) {
             overlay.render(drawContext, mouseX, mouseY, delta);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/CategoryTreeContainer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/CategoryTreeContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.wagyourgui.containers.MultiElementContainer;
 import com.jsmacrosce.wagyourgui.elements.Button;
@@ -164,7 +168,11 @@ public class CategoryTreeContainer extends MultiElementContainer<ICategoryTreePa
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
 
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/SettingsOverlay.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/SettingsOverlay.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.gui.settings;
 
 import com.google.common.collect.Lists;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 //? if >1.21.8 {
 /*import net.minecraft.client.input.KeyEvent;
 *///?}
@@ -137,7 +141,11 @@ public class SettingsOverlay extends OverlayContainer implements ICategoryTreePa
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
         int w = width - 4;
 
@@ -149,7 +157,11 @@ public class SettingsOverlay extends OverlayContainer implements ICategoryTreePa
 
         sections.render(drawContext, mouseX, mouseY, delta);
 
+        //? if >=26.1 {
+        /*drawContext.textWithWordWrap(textRenderer, title, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawWordWrap(textRenderer, title, x + 3, y + 3, width - 14, 0xFFFFFFFF, false);
+        //?}
         drawContext.fill(x + 2, y + 12, x + width - 2, y + 13, 0xFFFFFFFF);
 
         //sep

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingcontainer/AbstractMapSettingContainer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingcontainer/AbstractMapSettingContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
@@ -121,8 +125,16 @@ public abstract class AbstractMapSettingContainer<T, U extends AbstractMapSettin
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, settingName, (int) (x + width / 2F - textRenderer.width(settingName) / 2F + 20), y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, settingName, (int) (x + width / 2F - textRenderer.width(settingName) / 2F + 20), y + 1, 0xFFFFFFFF, false);
+        //?}
         drawContext.fill(x, y + 10, x + width, y + 11, 0xFFFFFFFF);
     }
 
@@ -194,7 +206,11 @@ public abstract class AbstractMapSettingContainer<T, U extends AbstractMapSettin
         }
 
         @Override
+        //? if >=26.1 {
+        /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+        *///?} else {
         public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        //?}
 
         }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingcontainer/PrimitiveSettingGroup.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingcontainer/PrimitiveSettingGroup.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingfields.*;
 import com.jsmacrosce.wagyourgui.elements.Scrollbar;
@@ -35,7 +39,11 @@ public class PrimitiveSettingGroup extends AbstractSettingContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         for (AbstractSettingField<?> setting : settings) {
             setting.render(drawContext, mouseX, mouseY, delta);
         }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/BooleanField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/BooleanField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -40,7 +44,11 @@ public class BooleanField extends AbstractSettingField<Boolean> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
 
     }
 

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/DoubleField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/DoubleField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -45,8 +49,16 @@ public class DoubleField extends AbstractSettingField<Double> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/FileField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/FileField.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
@@ -79,8 +83,16 @@ public class FileField extends AbstractSettingField<String> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/FloatField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/FloatField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -45,8 +49,16 @@ public class FloatField extends AbstractSettingField<Float> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/IntField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/IntField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -45,8 +49,16 @@ public class IntField extends AbstractSettingField<Integer> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/LongField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/LongField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -45,8 +49,16 @@ public class LongField extends AbstractSettingField<Long> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/OptionsField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/OptionsField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
@@ -50,8 +54,16 @@ public class OptionsField extends AbstractSettingField<Object> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/StringField.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/gui/settings/settingfields/StringField.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.gui.settings.settingfields;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import com.jsmacrosce.jsmacros.client.gui.settings.SettingsOverlay;
 import com.jsmacrosce.jsmacros.client.gui.settings.settingcontainer.AbstractSettingContainer;
@@ -41,8 +45,16 @@ public class StringField extends AbstractSettingField<String> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        *///?} else {
         drawContext.drawString(textRenderer, BaseScreen.trimmed(textRenderer, settingName, width / 2), x + 2, y + 1, 0xFFFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinChatHud.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinChatHud.java
@@ -1,8 +1,16 @@
 package com.jsmacrosce.jsmacros.client.mixin.access;
 
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessage;
+import net.minecraft.client.multiplayer.chat.GuiMessageTag;
+*///?} else {
 import net.minecraft.client.GuiMessage;
 import net.minecraft.client.GuiMessageTag;
+//?}
 import net.minecraft.client.gui.components.ChatComponent;
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessageSource;
+*///?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MessageSignature;
 import org.jetbrains.annotations.Nullable;
@@ -20,9 +28,15 @@ import java.util.List;
 @Mixin(ChatComponent.class)
 public abstract class MixinChatHud implements IChatHud {
 
+    //? if >=26.1 {
+    /*@Shadow
+    private void addMessage(Component message, @Nullable MessageSignature signature, GuiMessageSource source, @Nullable GuiMessageTag indicator) {
+    }
+    *///?} else {
     @Shadow
     private void addMessage(Component message, @Nullable MessageSignature signature, @Nullable GuiMessageTag indicator) {
     }
+    //?}
 
     @Shadow
     @Final
@@ -30,7 +44,11 @@ public abstract class MixinChatHud implements IChatHud {
 
     @Override
     public void jsmacros_addMessageBypass(Component message) {
+        //? if >=26.1 {
+        /*addMessage(message, null, GuiMessageSource.SYSTEM_CLIENT, GuiMessageTag.system());
+        *///?} else {
         addMessage(message, null, GuiMessageTag.system());
+        //?}
     }
 
     @Unique
@@ -39,20 +57,32 @@ public abstract class MixinChatHud implements IChatHud {
     @Override
     public void jsmacros_addMessageAtIndexBypass(Component message, int index, int time) {
         jsmacros$positionOverride.set(index);
+        //? if >=26.1 {
+        /*addMessage(message, null, GuiMessageSource.SYSTEM_CLIENT, GuiMessageTag.system());
+        *///?} else {
         addMessage(message, null, GuiMessageTag.system());
+        //?}
         jsmacros$positionOverride.set(0);
     }
 
-    //? if >=1.21.11 {
+    //? if >=26.1 {
     /*@Redirect(
+            method = "addMessageToQueue(Lnet/minecraft/client/multiplayer/chat/GuiMessage;)V",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;addFirst(Ljava/lang/Object;)V")
+    )
+    public <E> void overrideMessagePos(List<GuiMessage> instance, E guiMessage) {
+        this.allMessages.add(jsmacros$positionOverride.get(), (GuiMessage) guiMessage);
+    }
+    *///?} else if >=1.21.11 {
+    @Redirect(
             method = "addMessageToQueue(Lnet/minecraft/client/GuiMessage;)V",
             at = @At(value = "INVOKE", target = "Ljava/util/List;addFirst(Ljava/lang/Object;)V")
     )
     public <E> void overrideMessagePos(List<GuiMessage> instance, E guiMessage) {
         this.allMessages.add(jsmacros$positionOverride.get(), (GuiMessage) guiMessage);
     }
-    *///? } else {
-    @ModifyArg(
+    //?} else {
+    /*@ModifyArg(
         method = "addMessageToQueue(Lnet/minecraft/client/GuiMessage;)V",
         at = @At(
             value = "INVOKE",
@@ -63,7 +93,7 @@ public abstract class MixinChatHud implements IChatHud {
     public int overrideMessagePos(int pos) {
         return jsmacros$positionOverride.get();
     }
-    //? }
+    *///?}
 
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinHandledScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinHandledScreen.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.jsmacros.client.mixin.access;
 
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
@@ -54,18 +58,30 @@ public class MixinHandledScreen<T extends AbstractContainerMenu> extends Screen 
         return getHoveredSlot(x, y);
     }
 
-    @Inject(method = "renderSlot", at = @At("TAIL"))
-    //? if >=1.21.11 {
+    @Inject(
+            //? if >=26.1 {
+            /*method = "extractSlot",
+            *///?} else {
+            method = "renderSlot",
+            //?}
+            at = @At("TAIL"))
+    //? if >=26.1 {
+    /*private void onDrawSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int mouseX, int mouseY, CallbackInfo ci) {
+    *///?} else if >=1.21.11 {
     /*private void onDrawSlot(GuiGraphics guiGraphics, Slot slot, int mouseX, int mouseY, CallbackInfo ci) {
-    *///? } else {
+    *///?} else {
     private void onDrawSlot(GuiGraphics guiGraphics, Slot slot, CallbackInfo ci) {
-    //? }
+    //?}
         if (!JsMacrosClient.clientCore.config.getOptions(ClientConfigV2.class).showSlotIndexes) return;
 
         if (!slot.isActive()) return;
 
         int index = menu.slots.indexOf(slot);
+        //? if >=26.1 {
+        /*guiGraphics.text(Minecraft.getInstance().font, String.valueOf(index), slot.x, slot.y, 0xCCFFFFFF, false);
+        *///?} else {
         guiGraphics.drawString(Minecraft.getInstance().font, String.valueOf(index), slot.x, slot.y, 0xCCFFFFFF, false);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinInGameHud.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinInGameHud.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.client.mixin.access;
 
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.Gui;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -13,8 +17,13 @@ import com.jsmacrosce.jsmacros.client.api.library.impl.FHud;
 
 @Mixin(Gui.class)
 public class MixinInGameHud {
+    //? if >=26.1 {
+    /*@Inject(method = "extractRenderState", at = @At("TAIL"))
+    private void onRenderHud(GuiGraphicsExtractor context, DeltaTracker tickCounter, CallbackInfo ci) {
+    *///?} else {
     @Inject(method = "render", at = @At("TAIL"))
     private void onRenderHud(GuiGraphics context, DeltaTracker tickCounter, CallbackInfo ci) {
+    //?}
         if (!FHud.overlays.isEmpty()) {
             for (IDraw2D<Draw2D> overlay : FHud.overlays) {
                 overlay.render(context);

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemRenderer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemRenderer.java
@@ -3,7 +3,7 @@ package com.jsmacrosce.jsmacros.client.mixin.access;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
-//? if >=1.21.10 {
+//? if >=1.21.10 && <26.1 {
 /*import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.entity.ItemRenderer;

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemStackRenderState.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemStackRenderState.java
@@ -3,7 +3,7 @@ package com.jsmacrosce.jsmacros.client.mixin.access;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-//? if >=1.21.10 {
+//? if >=1.21.10 && <26.1 {
 /*import net.minecraft.client.renderer.item.ItemStackRenderState;
 
 @Mixin(ItemStackRenderState.class)

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemStackRenderStateLayer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinItemStackRenderStateLayer.java
@@ -3,7 +3,7 @@ package com.jsmacrosce.jsmacros.client.mixin.access;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-//? if >=1.21.10 {
+//? if >=1.21.10 && <26.1 {
 /*import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemTransform;
 import net.minecraft.client.renderer.item.ItemStackRenderState;

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinMinecraftClient.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinMinecraftClient.java
@@ -63,7 +63,14 @@ class MixinMinecraftClient {
     @Nullable
     public ClientLevel level;
 
-    @Inject(at = @At("TAIL"), method = "resizeDisplay")
+    @Inject(
+            at = @At("TAIL"),
+            //? if >=26.1 {
+            /*method = "resizeGui"
+            *///?} else {
+            method = "resizeDisplay"
+            //?}
+    )
     public void onResolutionChanged(CallbackInfo info) {
 
         synchronized (FHud.overlays) {
@@ -114,6 +121,15 @@ class MixinMinecraftClient {
     //? }
         InteractionProxy.reset();
     }
+
+    //? if >=26.1 {
+    /*@Inject(at = @At("HEAD"), method = "pick(F)V", cancellable = true)
+    private void onTargetUpdate(float tickDelta, CallbackInfo ci) {
+        if (InteractionProxy.Target.onUpdate(tickDelta)) {
+            ci.cancel();
+        }
+    }
+    *///?}
 
     @Inject(at = @At("HEAD"), method = "continueAttack", cancellable = true)
     private void overrideBlockBreaking(boolean breaking, CallbackInfo ci) {

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinScreen.java
@@ -4,7 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.jsmacrosce.doclet.DocletIgnore;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.*;
 import net.minecraft.client.gui.components.events.AbstractContainerEventHandler;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -908,7 +912,11 @@ public abstract class MixinScreen extends AbstractContainerEventHandler implemen
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void jsmacros_render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void jsmacros_render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         if (drawContext == null) {
             return;
         }
@@ -919,7 +927,11 @@ public abstract class MixinScreen extends AbstractContainerEventHandler implemen
 
             while (iter.hasNext()) {
                 RenderElement e = iter.next();
+                //? if >=26.1 {
+                /*e.extractRenderState(drawContext, mouseX, mouseY, delta);
+                *///?} else {
                 e.render(drawContext, mouseX, mouseY, delta);
+                //?}
                 if (e instanceof Text t) {
                     if (mouseX > t.x && mouseX < t.x + t.getWidth() && mouseY > t.y && mouseY < t.y + font.lineHeight) {
                         hoverText = t;
@@ -928,7 +940,15 @@ public abstract class MixinScreen extends AbstractContainerEventHandler implemen
             }
 
             if (hoverText != null) {
+                //? if >=26.1 {
+                /*// 26.1: renderComponentHoverEffect is private; hover effects are applied automatically
+                // when text is rendered through ActiveTextCollector.textRenderer(HoveredTextEffects)
+                // and drained via GuiGraphicsExtractor.extractDeferredElements. No standalone API
+                // exists for the manual out-of-band call pattern used here; our Text element paints
+                // raw strings so the auto path does not cover it. Functional gap tracked upstream.
+                *///?} else {
                 drawContext.renderComponentHoverEffect(font, TextUtil.componentStyleAtWidth(font, hoverText.text, mouseX - hoverText.x), mouseX, mouseY);
+                //?}
             }
         }
     }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinStyleSerializer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/access/MixinStyleSerializer.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(value = Style.Serializer.class, priority = 1001)
 public class MixinStyleSerializer {
 
+    //? if <26.1 {
     @ModifyExpressionValue(
         method = {"method_54215", "lambda$static$7"},
         at = @At(value = "FIELD", target = "Lnet/minecraft/network/chat/Style;clickEvent:Lnet/minecraft/network/chat/ClickEvent;", opcode = Opcodes.GETFIELD)
@@ -21,5 +22,6 @@ public class MixinStyleSerializer {
         }
         return original;
     }
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinChatHud.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinChatHud.java
@@ -1,8 +1,15 @@
 package com.jsmacrosce.jsmacros.client.mixin.events;
 
 import net.minecraft.ChatFormatting;
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessageTag;
+*///?} else {
 import net.minecraft.client.GuiMessageTag;
+//?}
 import net.minecraft.client.gui.components.ChatComponent;
+//? if >=26.1 {
+/*import net.minecraft.client.multiplayer.chat.GuiMessageSource;
+*///?}
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MessageSignature;
@@ -23,6 +30,21 @@ class MixinChatHud {
     @Unique
     private Component jsmacros$originalMessage;
 
+    //? if >=26.1 {
+    /*@Inject(
+            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onAddMessage1(Component message, MessageSignature signature, GuiMessageSource source, GuiMessageTag indicator, CallbackInfo ci) {
+        jsmacros$originalMessage = message;
+        jsmacros$eventRecvMessage = new EventRecvMessage(message, signature, indicator);
+        jsmacros$eventRecvMessage.trigger();
+        if (jsmacros$eventRecvMessage.isCanceled()) {
+            ci.cancel();
+        }
+    }
+    *///?} else {
     @Inject(
             method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
             at = @At("HEAD"),
@@ -36,12 +58,17 @@ class MixinChatHud {
             ci.cancel();
         }
     }
+    //?}
 
     @Unique
     private boolean jsmacros$modifiedEventRecieve;
 
     @ModifyVariable(
+            //? if >=26.1 {
+            /*method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            *///?} else {
             method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
+            //?}
             at = @At(value = "HEAD"),
             argsOnly = true
     )
@@ -66,7 +93,11 @@ class MixinChatHud {
     private final Component MODIFIED_TEXT = Component.translatable("jsmacrosce.chat.tag.modified").withStyle(ChatFormatting.UNDERLINE);
 
     @ModifyVariable(
+            //? if >=26.1 {
+            /*method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            *///?} else {
             method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
+            //?}
             at = @At(value = "HEAD"),
             argsOnly = true
     )
@@ -84,6 +115,18 @@ class MixinChatHud {
         }
     }
 
+    //? if >=26.1 {
+    /*@Inject(
+            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onAddChatMessage(Component message, MessageSignature signature, GuiMessageSource source, GuiMessageTag indicator, CallbackInfo ci) {
+        if (message == null) {
+            ci.cancel();
+        }
+    }
+    *///?} else {
     @Inject(
             method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
             at = @At("HEAD"),
@@ -94,5 +137,6 @@ class MixinChatHud {
             ci.cancel();
         }
     }
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinClientPlayNetworkHandler.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinClientPlayNetworkHandler.java
@@ -32,6 +32,7 @@ import com.jsmacrosce.jsmacros.client.api.event.impl.player.EventDeath;
 import com.jsmacrosce.jsmacros.client.api.event.impl.player.EventStatusEffectUpdate;
 import com.jsmacrosce.jsmacros.client.api.event.impl.world.*;
 import com.jsmacrosce.jsmacros.client.api.helper.StatusEffectHelper;
+import com.jsmacrosce.jsmacros.util.ChunkPosUtil;
 
 import java.util.*;
 
@@ -144,7 +145,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonPacketLi
 
     @Inject(at = @At("TAIL"), method = "handleForgetLevelChunk")
     public void onUnloadChunk(ClientboundForgetLevelChunkPacket packet, CallbackInfo info) {
-        new EventChunkUnload(packet.pos().x, packet.pos().z).trigger();
+        new EventChunkUnload(ChunkPosUtil.x(packet.pos()), ChunkPosUtil.z(packet.pos())).trigger();
     }
 
     @Inject(

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinClientPlayerInteractionManager.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinClientPlayerInteractionManager.java
@@ -10,6 +10,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -60,7 +61,11 @@ public class MixinClientPlayerInteractionManager {
     }
 
     @Inject(at = @At("RETURN"), method = "interact")
+    //? if >=26.1 {
+    /*public void onInteractEntity(Player player, Entity entity, EntityHitResult hitResult, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
+    *///?} else {
     public void onInteractEntity(Player player, Entity entity, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
+    //?}
         if (cir.getReturnValue() != InteractionResult.FAIL) {
             new EventInteractEntity(hand != InteractionHand.MAIN_HAND, cir.getReturnValue().consumesAction(), entity).trigger();
         }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinCreativeInventoryScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinCreativeInventoryScreen.java
@@ -2,15 +2,18 @@ package com.jsmacrosce.jsmacros.client.mixin.events;
 
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+//? if >=26.1 {
+/*import net.minecraft.world.inventory.ContainerInput;
+*///?} else {
 import net.minecraft.world.inventory.ClickType;
+//?}
 import net.minecraft.world.inventory.Slot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventClickSlot;
-import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventDropSlot;
+import com.jsmacrosce.jsmacros.util.SlotClickEventHelper;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -67,24 +70,22 @@ public abstract class MixinCreativeInventoryScreen {
         throw new NullPointerException("Unknown slot class");
     }
 
+    //? if >=26.1 {
+    /*@Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
+    public void beforeMouseClick(Slot slot, int slotId, int button, ContainerInput actionType, CallbackInfo ci) {
+        if (slot != null) {
+            slotId = jsmacros$getSlotFromCreativeSlot(slot).index;
+        }
+        SlotClickEventHelper.fire((AbstractContainerScreen<?>) (Object) this, actionType.id(), actionType == ContainerInput.THROW, button, slotId, ci);
+    }
+    *///?} else {
     @Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
     public void beforeMouseClick(Slot slot, int slotId, int button, ClickType actionType, CallbackInfo ci) {
         if (slot != null) {
             slotId = jsmacros$getSlotFromCreativeSlot(slot).index;
         }
-        EventClickSlot event = new EventClickSlot((AbstractContainerScreen<?>) (Object) this, actionType.ordinal(), button, slotId);
-        event.trigger();
-        if (event.isCanceled()) {
-            ci.cancel();
-            return;
-        }
-        if (actionType == ClickType.THROW || slotId == -999) {
-            EventDropSlot eventDrop = new EventDropSlot((AbstractContainerScreen<?>) (Object) this, slotId, button == 1);
-            eventDrop.trigger();
-            if (eventDrop.isCanceled()) {
-                ci.cancel();
-            }
-        }
+        SlotClickEventHelper.fire((AbstractContainerScreen<?>) (Object) this, actionType.ordinal(), actionType == ClickType.THROW, button, slotId, ci);
     }
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinHandledScreen.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinHandledScreen.java
@@ -1,33 +1,31 @@
 package com.jsmacrosce.jsmacros.client.mixin.events;
 
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+//? if >=26.1 {
+/*import net.minecraft.world.inventory.ContainerInput;
+*///?} else {
 import net.minecraft.world.inventory.ClickType;
+//?}
 import net.minecraft.world.inventory.Slot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventClickSlot;
-import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventDropSlot;
+import com.jsmacrosce.jsmacros.util.SlotClickEventHelper;
 
 @Mixin(AbstractContainerScreen.class)
 public class MixinHandledScreen {
 
+    //? if >=26.1 {
+    /*@Inject(method = "slotClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;handleContainerInput(IIILnet/minecraft/world/inventory/ContainerInput;Lnet/minecraft/world/entity/player/Player;)V"), cancellable = true)
+    public void beforeMouseClick(Slot slot, int slotId, int button, ContainerInput actionType, CallbackInfo ci) {
+        SlotClickEventHelper.fire((AbstractContainerScreen<?>) (Object) this, actionType.id(), actionType == ContainerInput.THROW, button, slotId, ci);
+    }
+    *///?} else {
     @Inject(method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ClickType;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;handleInventoryMouseClick(IIILnet/minecraft/world/inventory/ClickType;Lnet/minecraft/world/entity/player/Player;)V"), cancellable = true)
     public void beforeMouseClick(Slot slot, int slotId, int button, ClickType actionType, CallbackInfo ci) {
-        EventClickSlot event = new EventClickSlot((AbstractContainerScreen<?>) (Object) this, actionType.ordinal(), button, slotId);
-        event.trigger();
-        if (event.isCanceled()) {
-            ci.cancel();
-            return;
-        }
-        if (actionType == ClickType.THROW || slotId == -999) {
-            EventDropSlot eventDrop = new EventDropSlot((AbstractContainerScreen<?>) (Object) this, slotId, button == 1);
-            eventDrop.trigger();
-            if (eventDrop.isCanceled()) {
-                ci.cancel();
-            }
-        }
+        SlotClickEventHelper.fire((AbstractContainerScreen<?>) (Object) this, actionType.ordinal(), actionType == ClickType.THROW, button, slotId, ci);
     }
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinMessageHandler.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinMessageHandler.java
@@ -10,7 +10,11 @@ import com.jsmacrosce.jsmacros.client.api.event.impl.EventTitle;
 @Mixin(ChatListener.class)
 public class MixinMessageHandler {
 
+    //? if >=26.1 {
+    /*@ModifyArg(method = "handleOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V"))
+    *///?} else {
     @ModifyArg(method = "handleSystemMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;setOverlayMessage(Lnet/minecraft/network/chat/Component;Z)V"))
+    //?}
     private Component modifyOverlayMessage(Component text) {
         EventTitle et = new EventTitle("ACTIONBAR", text);
         et.trigger();

--- a/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinWorldRenderer.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/client/mixin/events/MixinWorldRenderer.java
@@ -15,7 +15,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.MultiBufferSource;
-        //? if >=1.21.11 {
+        //? if >=1.21.11 && <26.1 {
 /*import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Camera;
@@ -25,6 +25,9 @@ import net.minecraft.gizmos.Gizmos;
 import net.minecraft.gizmos.SimpleGizmoCollector;
 import org.joml.Matrix4f;
 import org.joml.Vector4f;
+*///?}
+        //? if >=26.1 {
+/*import net.minecraft.client.renderer.SubmitNodeStorage;
 *///?}
         //? if <=1.21.10 {
 import net.minecraft.world.phys.Vec3;
@@ -36,6 +39,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import com.jsmacrosce.jsmacros.client.JsMacros;
 import com.jsmacrosce.jsmacros.client.api.classes.render.Draw3D;
 import com.jsmacrosce.jsmacros.client.api.library.impl.FHud;
 
@@ -45,7 +49,58 @@ public class MixinWorldRenderer {
     @Shadow
     private LevelTargetBundle targets;
 
-    //? if >=1.21.11 {
+    //? if >=26.1 {
+    /*// 26.1: engine drains submitNodeStorage inside addMainPass (renderSolidFeatures →
+    // renderTranslucentFeatures → clearSubmitNodes at L659) before addWeatherPass runs,
+    // so any collector.submitItem(...) from this hook silently no-ops. MBS draws
+    // (lines/rects/boxes via bufferSource) still render. Retarget to INVOKE
+    // submitBlockDestroyAnimation in addMainPass (shift=AFTER) if Item3D support lands.
+    @Shadow
+    private SubmitNodeStorage submitNodeStorage;
+
+    @Inject(method = "addWeatherPass", at = @At("TAIL"))
+    private void onAddWeatherPass(
+            FrameGraphBuilder frameGraphBuilder,
+            GpuBufferSlice shaderFog,
+            CallbackInfo ci
+    ) {
+        jsmacrosce_addRenderPass(frameGraphBuilder, Minecraft.getInstance().getDeltaTracker());
+    }
+
+    @Unique
+    private void jsmacrosce_addRenderPass(FrameGraphBuilder frameGraphBuilder, DeltaTracker deltaTracker) {
+        if (this.targets == null) {
+            return;
+        }
+
+        SubmitNodeStorage capturedStorage = this.submitNodeStorage;
+
+        FramePass framePass = frameGraphBuilder.addPass("jsmacrosce_draw3d");
+        LevelTargetBundle frameBufferSet = this.targets;
+        frameBufferSet.main = framePass.readsAndWrites(frameBufferSet.main);
+
+        framePass.executes(() -> {
+            ProfilerFiller profiler = net.minecraft.util.profiling.Profiler.get();
+            profiler.push("jsmacrosce_d3d");
+
+            try {
+                MultiBufferSource.BufferSource consumers = Minecraft.getInstance().renderBuffers().bufferSource();
+                float tickDelta = deltaTracker.getGameTimeDeltaPartialTick(true);
+                PoseStack matrixStack = new PoseStack();
+
+                for (Draw3D d : ImmutableSet.copyOf(FHud.renders)) {
+                    d.render(matrixStack, consumers, capturedStorage, tickDelta);
+                }
+
+                consumers.endBatch();
+            } catch (Throwable e) {
+                JsMacros.LOGGER.error("Draw3D render error", e);
+            }
+
+            profiler.pop();
+        });
+    }
+    *///?} else if >=1.21.11 {
     /*@Shadow
     private LevelRenderState levelRenderState;
 
@@ -133,7 +188,7 @@ public class MixinWorldRenderer {
                 }
 
             } catch (Throwable e) {
-                e.printStackTrace();
+                JsMacros.LOGGER.error("Draw3D render error", e);
             }
 
             profiler.pop();
@@ -176,7 +231,7 @@ public class MixinWorldRenderer {
                 consumers.endBatch();
 
             } catch (Throwable e) {
-                e.printStackTrace();
+                JsMacros.LOGGER.error("Draw3D render error", e);
             }
 
             profiler.pop();
@@ -216,7 +271,7 @@ public class MixinWorldRenderer {
 
                 consumers.endBatch();
             } catch (Throwable e) {
-                e.printStackTrace();
+                JsMacros.LOGGER.error("Draw3D render error", e);
             }
 
             profiler.pop();
@@ -260,7 +315,7 @@ public class MixinWorldRenderer {
                 consumers.endBatch();
 
             } catch (Throwable e) {
-                e.printStackTrace();
+                JsMacros.LOGGER.error("Draw3D render error", e);
             }
 
             profiler.pop();

--- a/common/src/main/java/com/jsmacrosce/jsmacros/util/ChunkPosUtil.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/util/ChunkPosUtil.java
@@ -1,0 +1,23 @@
+package com.jsmacrosce.jsmacros.util;
+
+import net.minecraft.world.level.ChunkPos;
+
+public final class ChunkPosUtil {
+    private ChunkPosUtil() {}
+
+    public static int x(ChunkPos pos) {
+        //? if >=26.1 {
+        /*return pos.x();
+        *///?} else {
+        return pos.x;
+        //?}
+    }
+
+    public static int z(ChunkPos pos) {
+        //? if >=26.1 {
+        /*return pos.z();
+        *///?} else {
+        return pos.z;
+        //?}
+    }
+}

--- a/common/src/main/java/com/jsmacrosce/jsmacros/util/ContainerInputCompat.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/util/ContainerInputCompat.java
@@ -1,0 +1,48 @@
+package com.jsmacrosce.jsmacros.util;
+
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.world.entity.player.Player;
+//? if >=26.1 {
+/*import net.minecraft.world.inventory.ContainerInput;
+*///?} else {
+import net.minecraft.world.inventory.ClickType;
+//?}
+
+public final class ContainerInputCompat {
+    public static final int PICKUP = 0;
+    public static final int QUICK_MOVE = 1;
+    public static final int SWAP = 2;
+    public static final int CLONE = 3;
+    public static final int THROW = 4;
+    public static final int QUICK_CRAFT = 5;
+    public static final int PICKUP_ALL = 6;
+
+    private ContainerInputCompat() {}
+
+    public static void dispatch(MultiPlayerGameMode man, int syncId, int slotId, int button, int action, Player player) {
+        //? if >=26.1 {
+        /*man.handleContainerInput(syncId, slotId, button, toAction(action), player);
+        *///?} else {
+        man.handleInventoryMouseClick(syncId, slotId, button, toAction(action), player);
+        //?}
+    }
+
+    //? if >=26.1 {
+    /*private static ContainerInput toAction(int action) {
+        return switch (action) {
+            case PICKUP -> ContainerInput.PICKUP;
+            case QUICK_MOVE -> ContainerInput.QUICK_MOVE;
+            case SWAP -> ContainerInput.SWAP;
+            case CLONE -> ContainerInput.CLONE;
+            case THROW -> ContainerInput.THROW;
+            case QUICK_CRAFT -> ContainerInput.QUICK_CRAFT;
+            case PICKUP_ALL -> ContainerInput.PICKUP_ALL;
+            default -> throw new IllegalArgumentException("Unknown click action: " + action);
+        };
+    }
+    *///?} else {
+    private static ClickType toAction(int action) {
+        return ClickType.values()[action];
+    }
+    //?}
+}

--- a/common/src/main/java/com/jsmacrosce/jsmacros/util/InteractionCompat.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/util/InteractionCompat.java
@@ -1,0 +1,22 @@
+package com.jsmacrosce.jsmacros.util;
+
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+//? if >=26.1 {
+/*import net.minecraft.world.phys.EntityHitResult;
+*///?}
+
+public final class InteractionCompat {
+    private InteractionCompat() {}
+
+    public static InteractionResult interact(MultiPlayerGameMode gameMode, LocalPlayer player, Entity entity, InteractionHand hand) {
+        //? if >=26.1 {
+        /*return gameMode.interact(player, entity, new EntityHitResult(entity), hand);
+        *///?} else {
+        return gameMode.interact(player, entity, hand);
+        //?}
+    }
+}

--- a/common/src/main/java/com/jsmacrosce/jsmacros/util/SlotClickEventHelper.java
+++ b/common/src/main/java/com/jsmacrosce/jsmacros/util/SlotClickEventHelper.java
@@ -1,0 +1,26 @@
+package com.jsmacrosce.jsmacros.util;
+
+import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventClickSlot;
+import com.jsmacrosce.jsmacros.client.api.event.impl.inventory.EventDropSlot;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+public final class SlotClickEventHelper {
+    private SlotClickEventHelper() {}
+
+    public static void fire(AbstractContainerScreen<?> screen, int actionId, boolean isThrow, int button, int slotId, CallbackInfo ci) {
+        EventClickSlot event = new EventClickSlot(screen, actionId, button, slotId);
+        event.trigger();
+        if (event.isCanceled()) {
+            ci.cancel();
+            return;
+        }
+        if (isThrow || slotId == -999) {
+            EventDropSlot eventDrop = new EventDropSlot(screen, slotId, button == 1);
+            eventDrop.trigger();
+            if (eventDrop.isCanceled()) {
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/BaseScreen.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/BaseScreen.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -193,7 +197,11 @@ public abstract class BaseScreen extends Screen implements IOverlayParent {
     //?}
 
     @Override
+    //? if >=26.1 {
+    /*public void extractRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         //? if <=1.21.5 {
         /*this.renderBackground(drawContext, mouseX, mouseY, delta);
         *///?}

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/containers/CheckBoxContainer.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/containers/CheckBoxContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.containers;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.wagyourgui.elements.Button;
 
@@ -40,9 +44,17 @@ public class CheckBoxContainer extends MultiElementContainer<IContainerParent> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         if (this.visible) {
+            //? if >=26.1 {
+            /*drawContext.textWithWordWrap(textRenderer, message, x + height, y + 2, width - height - 2, 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawWordWrap(textRenderer, message, x + height, y + 2, width - height - 2, 0xFFFFFFFF, false);
+            //?}
         }
     }
 

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/containers/ListContainer.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/containers/ListContainer.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.wagyourgui.containers;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import com.jsmacrosce.wagyourgui.elements.Button;
@@ -64,7 +68,11 @@ public class ListContainer extends MultiElementContainer<IContainerParent> {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
 
         for (AbstractWidget b : ImmutableList.copyOf(this.buttons)) {
             if (b instanceof Button && ((Button) b).hovering && ((Button) b).cantRenderAllText()) {
@@ -77,7 +85,11 @@ public class ListContainer extends MultiElementContainer<IContainerParent> {
 
                 // fill
                 drawContext.fill(mouseX - 2, mouseY - textRenderer.lineHeight - 3, mouseX + width + 2, mouseY, 0xFF000000);
+                //? if >=26.1 {
+                /*drawContext.text(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                *///?} else {
                 drawContext.drawString(textRenderer, b.getMessage(), mouseX, mouseY - textRenderer.lineHeight - 1, 0xFFFFFFFF);
+                //?}
             }
         }
     }

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/containers/MultiElementContainer.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/containers/MultiElementContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.containers;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -86,6 +90,10 @@ public abstract class MultiElementContainer<T extends IContainerParent> implemen
         return parent.getFirstOverlayParent();
     }
 
+    //? if >=26.1 {
+    /*public abstract void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta);
+    *///?} else {
     public abstract void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta);
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/elements/AnnotatedCheckBox.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/elements/AnnotatedCheckBox.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.elements;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 //? if >1.21.8 {
 /*import net.minecraft.client.input.InputWithModifiers;
 *///?}
@@ -42,20 +46,30 @@ public class AnnotatedCheckBox extends Button {
     }
 
     @Override
+    //? if >=26.1 {
+    /*protected void renderMessage(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     protected void renderMessage(GuiGraphics drawContext) {
+    //?}
         int width = this.width - height;
         for (int i = 0; i < visibleLines; ++i) {
             int w = textRenderer.width(textLines.get(i));
+            //? if >=26.1 {
+            /*drawContext.text(textRenderer, textLines.get(i), (int) (horizCenter ? getX() + width / 2F - w / 2F : getX() + 2), getY() + 2 + verticalCenter + (i * textRenderer.lineHeight), textColor, false);
+            *///?} else {
             drawContext.drawString(textRenderer, textLines.get(i), (int) (horizCenter ? getX() + width / 2F - w / 2F : getX() + 2), getY() + 2 + verticalCenter + (i * textRenderer.lineHeight), textColor, false);
+            //?}
         }
     }
 
     @Override
-    //? if >=1.21.11 {
+    //? if >=26.1 {
+    /*protected void extractContents(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else if >=1.21.11 {
     /*public void renderContents(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-    *///? } else {
+    *///?} else {
     public void renderWidget(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-    //? }
+    //?}
         if (this.visible) {
             this.renderMessage(drawContext);
 

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Button.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Button.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.elements;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
@@ -81,19 +85,29 @@ public class Button extends AbstractButton {
         this.textColor = ColorUtil.fixAlpha(color);
     }
 
+    //? if >=26.1 {
+    /*protected void renderMessage(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     protected void renderMessage(GuiGraphics drawContext) {
+    //?}
         for (int i = 0; i < visibleLines; ++i) {
             int w = textRenderer.width(textLines.get(i));
+            //? if >=26.1 {
+            /*drawContext.text(textRenderer, textLines.get(i), (int) (horizCenter ? getX() + width / 2F - w / 2F : getX() + 2), getY() + 2 + verticalCenter + (i * textRenderer.lineHeight), textColor, false);
+            *///?} else {
             drawContext.drawString(textRenderer, textLines.get(i), (int) (horizCenter ? getX() + width / 2F - w / 2F : getX() + 2), getY() + 2 + verticalCenter + (i * textRenderer.lineHeight), textColor, false);
+            //?}
         }
     }
 
     @Override
-    //? if >=1.21.11 {
+    //? if >=26.1 {
+    /*protected void extractContents(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else if >=1.21.11 {
     /*public void renderContents(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-    *///? } else {
+    *///?} else {
     public void renderWidget(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-    //? }
+    //?}
         if (this.visible) {
             // fill
             if (mouseX - getX() >= 0 && mouseX - getX() - width < 0 && mouseY - getY() >= 0 && mouseY - getY() - height < 0 && this.active || forceHover) {

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Scrollbar.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Scrollbar.java
@@ -1,6 +1,10 @@
 package com.jsmacrosce.wagyourgui.elements;
 
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
@@ -111,7 +115,11 @@ public class Scrollbar extends AbstractWidget {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void extractWidgetRenderState(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void renderWidget(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         // mainpart
         drawContext.fill(getX() + 1, (int) (getY() + 1 + scrollAmount), getX() + width - 1, (int) (getY() + 1 + scrollAmount + scrollbarHeight), highlightColor);
 

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Slider.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/elements/Slider.java
@@ -3,7 +3,11 @@ package com.jsmacrosce.wagyourgui.elements;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -105,7 +109,11 @@ public class Slider extends AbstractWidget {
     }
 
     @Override
+    //? if >=26.1 {
+    /*protected void extractWidgetRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+    *///?} else {
     protected void renderWidget(GuiGraphics context, int mouseX, int mouseY, float delta) {
+    //?}
         //? if >1.21.5 {
         RenderPipeline renderType = RenderPipelines.GUI_TEXTURED;
         //?} else {

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/elements/TextInput.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/elements/TextInput.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.wagyourgui.elements;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.screens.Screen;
 //? if >1.21.8 {
 /*import net.minecraft.client.input.CharacterEvent;
@@ -252,10 +256,19 @@ public class TextInput extends Button {
     }
 
     @Override
+    //? if >=26.1 {
+    /*protected void renderMessage(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     protected void renderMessage(GuiGraphics drawContext) {
+    //?}
         drawContext.fill(selStart, height > 9 ? getY() + 2 : getY(), Math.min(selEnd, getX() + width - 2), (height > 9 ? getY() + 2 : getY()) + textRenderer.lineHeight, selColor);
+        //? if >=26.1 {
+        /*drawContext.text(textRenderer, textRenderer.plainSubstrByWidth(content, width - 4), getX() + 2, height > 9 ? getY() + 2 :
+                getY(), textColor);
+        *///?} else {
         drawContext.drawString(textRenderer, textRenderer.plainSubstrByWidth(content, width - 4), getX() + 2, height > 9 ? getY() + 2 :
                 getY(), textColor);
+        //?}
     }
 
 }

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/ConfirmOverlay.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/ConfirmOverlay.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
 import com.jsmacrosce.wagyourgui.elements.Button;
@@ -50,16 +54,28 @@ public class ConfirmOverlay extends OverlayContainer {
 
     }
 
+    //? if >=26.1 {
+    /*protected void renderMessage(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     protected void renderMessage(GuiGraphics drawContext) {
+    //?}
         for (int i = 0; i < lines; ++i) {
             int w = textRenderer.width(text.get(i));
             int centeredX = (int) (hcenter ? x + width / 2F - w / 2F : x + 3);
+            //? if >=26.1 {
+            /*drawContext.text(textRenderer, text.get(i), centeredX, y + 2 + vcenter + (i * textRenderer.lineHeight), 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawString(textRenderer, text.get(i), centeredX, y + 2 + vcenter + (i * textRenderer.lineHeight), 0xFFFFFFFF, false);
+            //?}
         }
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         this.renderBackground(drawContext);
         drawContext.fill(x + 1, y + height - 13, x + width - 1, y + height - 12, 0xFFFFFFFF);
         this.renderMessage(drawContext);

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/OverlayContainer.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/OverlayContainer.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import com.jsmacrosce.wagyourgui.containers.MultiElementContainer;
@@ -126,7 +130,11 @@ public abstract class OverlayContainer extends MultiElementContainer<IOverlayPar
     public void onClose() {
     }
 
+    //? if >=26.1 {
+    /*public void renderBackground(GuiGraphicsExtractor drawContext) {
+    *///?} else {
     public void renderBackground(GuiGraphics drawContext) {
+    //?}
         // black bg
         drawContext.fill(x, y, x + width, y + height, 0xFF000000);
         // 2 layer border
@@ -143,6 +151,16 @@ public abstract class OverlayContainer extends MultiElementContainer<IOverlayPar
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+        for (AbstractWidget btn : buttons) {
+            btn.extractRenderState(drawContext, mouseX, mouseY, delta);
+        }
+        if (this.overlay != null) {
+            this.overlay.render(drawContext, mouseX, mouseY, delta);
+        }
+    }
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
         for (AbstractWidget btn : buttons) {
             btn.render(drawContext, mouseX, mouseY, delta);
@@ -151,5 +169,6 @@ public abstract class OverlayContainer extends MultiElementContainer<IOverlayPar
             this.overlay.render(drawContext, mouseX, mouseY, delta);
         }
     }
+    //?}
 
 }

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/SelectorDropdownOverlay.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/SelectorDropdownOverlay.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 //? if >1.21.8 {
 /*import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
@@ -122,7 +126,11 @@ public class SelectorDropdownOverlay extends OverlayContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         renderBackground(drawContext);
         super.render(drawContext, mouseX, mouseY, delta);
     }

--- a/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/TextPrompt.java
+++ b/common/src/main/java/com/jsmacrosce/wagyourgui/overlays/TextPrompt.java
@@ -1,7 +1,11 @@
 package com.jsmacrosce.wagyourgui.overlays;
 
 import net.minecraft.client.gui.Font;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
 import com.jsmacrosce.wagyourgui.elements.Button;
@@ -43,11 +47,19 @@ public class TextPrompt extends OverlayContainer {
     }
 
     @Override
+    //? if >=26.1 {
+    /*public void render(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+    *///?} else {
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+    //?}
         this.renderBackground(drawContext);
         int lineNum = 0;
         for (FormattedCharSequence line : textRenderer.split(message, width - 4)) {
+            //? if >=26.1 {
+            /*drawContext.text(textRenderer, line, (int) (x + width / 2F - textRenderer.width(line) / 2F), y + 5 + (lineNum++) * textRenderer.lineHeight, 0xFFFFFFFF, false);
+            *///?} else {
             drawContext.drawString(textRenderer, line, (int) (x + width / 2F - textRenderer.width(line) / 2F), y + 5 + (lineNum++) * textRenderer.lineHeight, 0xFFFFFFFF, false);
+            //?}
         }
         super.render(drawContext, mouseX, mouseY, delta);
     }

--- a/common/src/main/resources/accesswideners/26.1.2-jsmacrosce.accesswidener
+++ b/common/src/main/resources/accesswideners/26.1.2-jsmacrosce.accesswidener
@@ -1,0 +1,42 @@
+accessWidener v2 official
+
+accessible field net/minecraft/client/gui/components/BossHealthOverlay events Ljava/util/Map;
+accessible field net/minecraft/client/gui/components/ChatComponent allMessages Ljava/util/List;
+
+accessible field net/minecraft/client/gui/screens/inventory/BeaconScreen primary Lnet/minecraft/core/Holder;
+accessible field net/minecraft/client/gui/screens/inventory/BeaconScreen secondary Lnet/minecraft/core/Holder;
+accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen skipNextRelease Z
+accessible field net/minecraft/client/gui/screens/inventory/AbstractRecipeBookScreen recipeBookComponent Lnet/minecraft/client/gui/screens/recipebook/RecipeBookComponent;
+accessible field net/minecraft/client/gui/screens/recipebook/RecipeBookComponent tabInfos Ljava/util/List;
+
+accessible field net/minecraft/client/Minecraft fontManager Lnet/minecraft/client/gui/font/FontManager;
+accessible method net/minecraft/client/Minecraft startUseItem ()V
+accessible method net/minecraft/client/Minecraft startAttack ()Z
+accessible method net/minecraft/client/Minecraft getConnection ()Lnet/minecraft/client/multiplayer/ClientPacketListener;
+
+accessible method net/minecraft/client/multiplayer/ClientPacketListener getCommands ()Lcom/mojang/brigadier/CommandDispatcher;
+
+accessible field net/minecraft/client/player/ClientInput moveVector Lnet/minecraft/world/phys/Vec2;
+accessible method net/minecraft/client/player/KeyboardInput calculateImpulse (ZZ)F
+
+accessible field net/minecraft/client/OptionInstance value Ljava/lang/Object;
+
+accessible field net/minecraft/world/entity/player/StackedItemContents raw Lnet/minecraft/world/entity/player/StackedContents;
+
+accessible field net/minecraft/world/level/block/entity/FuelValues values Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;
+
+accessible field net/minecraft/world/entity/vehicle/boat/AbstractBoat status Lnet/minecraft/world/entity/vehicle/boat/AbstractBoat$Status;
+
+accessible field net/minecraft/world/entity/animal/dolphin/Dolphin treasurePos Lnet/minecraft/core/BlockPos;
+accessible method net/minecraft/world/entity/animal/fish/TropicalFish getPackedVariant ()I
+accessible field net/minecraft/world/entity/animal/wolf/Wolf isWet Z
+
+accessible field net/minecraft/world/entity/player/Player DATA_SHOULDER_PARROT_LEFT Lnet/minecraft/network/syncher/EntityDataAccessor;
+accessible field net/minecraft/world/entity/player/Player DATA_SHOULDER_PARROT_RIGHT Lnet/minecraft/network/syncher/EntityDataAccessor;
+
+accessible class net/minecraft/client/StringSplitter$WidthLimitedCharSink
+
+accessible field net/minecraft/client/renderer/RenderPipelines DEBUG_FILLED_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
+accessible field net/minecraft/client/renderer/RenderPipelines ENTITY_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
+accessible method net/minecraft/client/renderer/rendertype/RenderType create (Ljava/lang/String;Lnet/minecraft/client/renderer/rendertype/RenderSetup;)Lnet/minecraft/client/renderer/rendertype/RenderType;
+accessible method net/minecraft/client/renderer/RenderPipelines register (Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lcom/mojang/blaze3d/pipeline/RenderPipeline;

--- a/extension/ruby/build.gradle.kts
+++ b/extension/ruby/build.gradle.kts
@@ -1,0 +1,82 @@
+import org.gradle.language.jvm.tasks.ProcessResources
+
+plugins {
+    `java-library`
+}
+
+base {
+    archivesName.set("${property("mod_id")}-ruby")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(property("java_version").toString().toInt()))
+    }
+    withSourcesJar()
+}
+
+repositories {
+    mavenCentral()
+}
+
+// Get minecraft version from stonecutter.active file
+val minecraftVersion = rootProject.file("stonecutter.active").takeIf { it.exists() }
+    ?.readText()?.trim()?.ifEmpty { null }
+    ?: throw GradleException("stonecutter.active is empty; set an active version first")
+
+// Configuration for runtime dependencies to embed in the extension jar
+val embedDeps by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    // Depends on extension module
+    implementation(project(":extension"))
+
+    // Compile against shared common code
+    compileOnly(project(":common:${minecraftVersion}"))
+    compileOnly("org.jetbrains:annotations:20.1.0")
+
+    // JRuby runtime - embedded into the extension jar so users don't need it on the classpath
+    implementation("org.jruby:jruby-complete:9.4.5.0")
+    add(embedDeps.name, "org.jruby:jruby-complete:9.4.5.0")
+
+    // Common library dependencies, google deps must align with neoforged
+    implementation("com.google.guava:guava:31.1-jre")
+    implementation("com.google.code.gson:gson:2.10")
+    implementation("org.slf4j:slf4j-api:2.0.16")
+
+    // Test dependencies
+    testImplementation(project(":extension"))
+    testImplementation(project(":common:${minecraftVersion}"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testImplementation("org.jetbrains:annotations:20.1.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+}
+
+// Collect embedded dependency paths for the json file
+fun getEmbeddedDepPaths(): String =
+    embedDeps.files.joinToString(", ") { file ->
+        "\"META-INF/jsmacroscedeps/${file.name}\""
+    }
+
+// Process resources to expand dependencies placeholder
+tasks.named<ProcessResources>("processResources") {
+    filesMatching("jsmacrosce.ext.jruby.json") {
+        expand(mapOf("dependencies" to getEmbeddedDepPaths()))
+    }
+}
+
+// Embed dependencies into the extension jar
+tasks.named<Jar>("jar") {
+    dependsOn(embedDeps)
+    from(embedDeps) {
+        into("META-INF/jsmacroscedeps")
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/client/JRubyExtension.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/client/JRubyExtension.java
@@ -1,0 +1,128 @@
+package com.jsmacrosce.jsmacros.jruby.client;
+
+import com.google.common.collect.Sets;
+import org.jruby.RubyException;
+import org.jruby.embed.EvalFailedException;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
+import org.jruby.runtime.builtin.IRubyObject;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.extensions.LanguageExtension;
+import com.jsmacrosce.jsmacros.core.extensions.LibraryExtension;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.language.BaseWrappedException;
+import com.jsmacrosce.jsmacros.core.library.BaseLibrary;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyLanguageDefinition;
+import com.jsmacrosce.jsmacros.jruby.library.impl.FWrapper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+
+public class JRubyExtension implements LanguageExtension, LibraryExtension {
+
+    private static JRubyLanguageDefinition languageDefinition;
+
+    @Override
+    public String getExtensionName() {
+        return "jruby";
+    }
+
+    @Override
+    public void init(Core<?, ?> runner) {
+        Thread t = new Thread(() -> {
+            ScriptingContainer instance = new ScriptingContainer();
+            instance.runScriptlet("p \"Ruby Pre-Loaded\"");
+            instance.terminate();
+        }, "JRuby-Preload");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public ExtMatch extensionMatch(File file) {
+        if (file.getName().endsWith(".rb")) {
+            if (file.getName().contains(getExtensionName())) {
+                return ExtMatch.MATCH_WITH_NAME;
+            } else {
+                return ExtMatch.MATCH;
+            }
+        }
+        return ExtMatch.NOT_MATCH;
+    }
+
+    @Override
+    public String defaultFileExtension() {
+        return "rb";
+    }
+
+    @Override
+    public synchronized BaseLanguage<?, ?> getLanguage(Core<?, ?> runner) {
+        if (languageDefinition == null) {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(JRubyExtension.class.getClassLoader());
+            try {
+                languageDefinition = new JRubyLanguageDefinition(this, runner);
+            } finally {
+                Thread.currentThread().setContextClassLoader(classLoader);
+            }
+        }
+        return languageDefinition;
+    }
+
+    @Override
+    public Set<Class<? extends BaseLibrary>> getLibraries() {
+        return Sets.newHashSet(FWrapper.class);
+    }
+
+    @Override
+    public BaseWrappedException<?> wrapException(Throwable ex) {
+        if (!(ex instanceof EvalFailedException)) return null;
+        Throwable cause = ex.getCause();
+        if (cause instanceof RaiseException) {
+            RubyException e = ((RaiseException) cause).getException();
+            StackTraceElement[] frames = Arrays.stream(e.getBacktraceElements())
+                    .map(RubyStackTraceElement::asStackTraceElement)
+                    .toArray(StackTraceElement[]::new);
+            return new BaseWrappedException<>(e, e.getMessageAsJavaString(), null, buildTrace(frames));
+        }
+        return new BaseWrappedException<>(cause, cause.getClass().getName() + ": " + cause.getMessage(), null, buildTrace(cause.getStackTrace()));
+    }
+
+    private BaseWrappedException<StackTraceElement> buildTrace(StackTraceElement[] frames) {
+        BaseWrappedException<StackTraceElement> head = null;
+        for (int i = frames.length - 1; i >= 0; i--) {
+            StackTraceElement frame = frames[i];
+            String cls = frame.getClassName();
+            if ("org.jruby.embed.internal.EmbedEvalUnitImpl".equals(cls)) {
+                // upstream ran here — discard everything we've accumulated above it in the chain
+                head = null;
+                continue;
+            }
+            if (cls.startsWith("org.jruby")) continue;
+            BaseWrappedException.SourceLocation loc;
+            if ("RUBY".equals(cls)) {
+                String fileName = frame.getFileName();
+                loc = new BaseWrappedException.GuestLocation(
+                        fileName != null ? new File(fileName) : null,
+                        -1, -1, frame.getLineNumber(), -1);
+            } else {
+                loc = new BaseWrappedException.HostLocation(cls + " " + frame.getLineNumber());
+            }
+            head = new BaseWrappedException<>(frame, frame.getMethodName(), loc, head);
+        }
+        return head;
+    }
+
+    @Override
+    public boolean isGuestObject(Object o) {
+        return o instanceof IRubyObject;
+    }
+
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyLanguageDefinition.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyLanguageDefinition.java
@@ -1,0 +1,81 @@
+package com.jsmacrosce.jsmacros.jruby.language.impl;
+
+import org.jruby.embed.LocalContextScope;
+import org.jruby.embed.ScriptingContainer;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.config.ScriptTrigger;
+import com.jsmacrosce.jsmacros.core.event.BaseEvent;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.language.EventContainer;
+import com.jsmacrosce.jsmacros.jruby.client.JRubyExtension;
+
+import org.jetbrains.annotations.Nullable;
+import java.io.File;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JRubyLanguageDefinition extends BaseLanguage<ScriptingContainer, JRubyScriptContext> {
+    public JRubyLanguageDefinition(JRubyExtension extension, Core<?, ?> runner) {
+        super(extension, runner);
+    }
+
+    private void runInstance(EventContainer<JRubyScriptContext> ctx, BaseEvent event, ScriptletRunner scriptlet, @Nullable Path cwd) throws Exception {
+        ScriptingContainer instance = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
+        ctx.getCtx().setContext(instance);
+
+        if (cwd != null) {
+            instance.setCurrentDirectory(cwd.toString());
+        }
+
+        retrieveLibs(ctx.getCtx()).forEach((name, lib) -> {
+            // "Time" is a built-in Ruby class; expose jsmacros' Time library under FTime instead.
+            String bindName = "Time".equals(name) ? "FTime" : name;
+            instance.put(bindName, lib);
+        });
+        instance.put("event", event);
+        instance.put("file", ctx.getCtx().getFile());
+        instance.put("context", ctx);
+
+        scriptlet.run(instance);
+    }
+
+    @Override
+    protected void exec(EventContainer<JRubyScriptContext> ctx, ScriptTrigger macro, BaseEvent event) throws Exception {
+        File file = ctx.getCtx().getFile();
+        runInstance(ctx, event, instance -> {
+            try (Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                instance.runScriptlet(reader, file.getAbsolutePath());
+            }
+        }, parentPathOf(file));
+    }
+
+    @Override
+    protected void exec(EventContainer<JRubyScriptContext> ctx, String lang, String script, BaseEvent event) throws Exception {
+        File file = ctx.getCtx().getFile();
+        runInstance(ctx, event, instance -> {
+            if (file != null) {
+                instance.runScriptlet(new StringReader(script), file.getAbsolutePath());
+            } else {
+                instance.runScriptlet(script);
+            }
+        }, parentPathOf(file));
+    }
+
+    @Override
+    public JRubyScriptContext createContext(BaseEvent event, File path) {
+        return new JRubyScriptContext(runner, event, path);
+    }
+
+    private static @Nullable Path parentPathOf(@Nullable File f) {
+        if (f == null) return null;
+        File parent = f.getParentFile();
+        return parent != null ? parent.toPath() : null;
+    }
+
+    private interface ScriptletRunner {
+        void run(ScriptingContainer instance) throws Exception;
+    }
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyScriptContext.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/language/impl/JRubyScriptContext.java
@@ -1,0 +1,29 @@
+package com.jsmacrosce.jsmacros.jruby.language.impl;
+
+import org.jruby.embed.ScriptingContainer;
+import com.jsmacrosce.jsmacros.core.Core;
+import com.jsmacrosce.jsmacros.core.event.BaseEvent;
+import com.jsmacrosce.jsmacros.core.language.BaseScriptContext;
+
+import java.io.File;
+
+public class JRubyScriptContext extends BaseScriptContext<ScriptingContainer> {
+    public JRubyScriptContext(Core<?, ?> runner, BaseEvent event, File file) {
+        super(runner, event, file);
+    }
+
+    @Override
+    public synchronized void closeContext() {
+        super.closeContext();
+        ScriptingContainer ctx = getContext();
+        if (ctx != null) {
+            ctx.terminate();
+        }
+    }
+
+    @Override
+    public boolean isMultiThreaded() {
+        return true;
+    }
+
+}

--- a/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/library/impl/FWrapper.java
+++ b/extension/ruby/src/main/java/com/jsmacrosce/jsmacros/jruby/library/impl/FWrapper.java
@@ -1,0 +1,152 @@
+package com.jsmacrosce.jsmacros.jruby.library.impl;
+
+import org.jruby.RubyMethod;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import com.jsmacrosce.jsmacros.core.MethodWrapper;
+import com.jsmacrosce.jsmacros.core.language.BaseLanguage;
+import com.jsmacrosce.jsmacros.core.library.IFWrapper;
+import com.jsmacrosce.jsmacros.core.library.Library;
+import com.jsmacrosce.jsmacros.core.library.PerExecLanguageLibrary;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyLanguageDefinition;
+import com.jsmacrosce.jsmacros.jruby.language.impl.JRubyScriptContext;
+
+@Library(value = "JavaWrapper", languages = JRubyLanguageDefinition.class)
+public class FWrapper extends PerExecLanguageLibrary<ScriptingContainer, JRubyScriptContext> implements IFWrapper<RubyMethod> {
+
+    public FWrapper(JRubyScriptContext context, Class<? extends BaseLanguage<ScriptingContainer, JRubyScriptContext>> language) {
+        super(context, language);
+    }
+
+    @Override
+    public <A, B, R> MethodWrapper<A, B, R, ?> methodToJava(RubyMethod c) {
+        return new RubyMethodWrapper<>(c, true, ctx);
+    }
+
+    @Override
+    public <A, B, R> MethodWrapper<A, B, R, ?> methodToJavaAsync(RubyMethod c) {
+        return new RubyMethodWrapper<>(c, false, ctx);
+    }
+
+    @Override
+    public void stop() {
+        ctx.closeContext();
+    }
+
+    private static class RubyMethodWrapper<T, U, R> extends MethodWrapper<T, U, R, JRubyScriptContext> {
+        private final RubyMethod fn;
+        private final boolean await;
+
+        RubyMethodWrapper(RubyMethod fn, boolean await, JRubyScriptContext ctx) {
+            super(ctx);
+            this.fn = fn;
+            this.await = await;
+        }
+
+        private Object callFn(Object... params) {
+            ThreadContext threadContext = ctx.getContext().getProvider().getRuntime().getCurrentContext();
+            threadContext.pushNewScope(threadContext.getCurrentStaticScope());
+            try {
+                IRubyObject[] rubyObjects = JavaUtil.convertJavaArrayToRuby(threadContext.runtime, params);
+                return fn.call(threadContext, rubyObjects, threadContext.getFrameBlock()).toJava(Object.class);
+            } finally {
+                threadContext.popScope();
+            }
+        }
+
+        private void innerAccept(Object... params) {
+            if (await) {
+                innerApply(params);
+                return;
+            }
+
+            Thread t = new Thread(() -> {
+                ctx.bindThread(Thread.currentThread());
+                try {
+                    callFn(params);
+                } catch (Throwable ex) {
+                    ctx.runner.profile.logError(ex);
+                } finally {
+                    ctx.unbindThread(Thread.currentThread());
+                    ctx.runner.profile.joinedThreadStack.remove(Thread.currentThread());
+                    ctx.releaseBoundEventIfPresent(Thread.currentThread());
+                }
+            }, "JRuby-JavaWrapper");
+            t.setDaemon(true);
+            t.start();
+        }
+
+        @SuppressWarnings("unchecked")
+        private <R2> R2 innerApply(Object... params) {
+            if (ctx.getBoundThreads().contains(Thread.currentThread())) {
+                return (R2) callFn(params);
+            }
+
+            try {
+                ctx.bindThread(Thread.currentThread());
+                if (ctx.runner.profile.checkJoinedThreadStack()) {
+                    ctx.runner.profile.joinedThreadStack.add(Thread.currentThread());
+                }
+                return (R2) callFn(params);
+            } catch (Throwable ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                ctx.releaseBoundEventIfPresent(Thread.currentThread());
+                ctx.unbindThread(Thread.currentThread());
+                ctx.runner.profile.joinedThreadStack.remove(Thread.currentThread());
+            }
+        }
+
+        @Override
+        public void accept(T t) {
+            innerAccept(t);
+        }
+
+        @Override
+        public void accept(T t, U u) {
+            innerAccept(t, u);
+        }
+
+        @Override
+        public R apply(T t) {
+            return innerApply(t);
+        }
+
+        @Override
+        public R apply(T t, U u) {
+            return innerApply(t, u);
+        }
+
+        @Override
+        public boolean test(T t) {
+            return (boolean) innerApply(t);
+        }
+
+        @Override
+        public boolean test(T t, U u) {
+            return (boolean) innerApply(t, u);
+        }
+
+        @Override
+        public void run() {
+            innerAccept();
+        }
+
+        @Override
+        public int compare(T o1, T o2) {
+            Object result = innerApply(o1, o2);
+            if (!(result instanceof Number)) {
+                throw new ClassCastException("Ruby comparator must return a numeric value, got: " + result);
+            }
+            return ((Number) result).intValue();
+        }
+
+        @Override
+        public R get() {
+            return innerApply();
+        }
+    }
+
+}

--- a/extension/ruby/src/main/resources/META-INF/services/com.jsmacrosce.jsmacros.core.extensions.Extension
+++ b/extension/ruby/src/main/resources/META-INF/services/com.jsmacrosce.jsmacros.core.extensions.Extension
@@ -1,0 +1,1 @@
+com.jsmacrosce.jsmacros.jruby.client.JRubyExtension

--- a/extension/ruby/src/main/resources/jsmacrosce.ext.jruby.json
+++ b/extension/ruby/src/main/resources/jsmacrosce.ext.jruby.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": [${dependencies}]
+}

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,9 +1,15 @@
 import org.gradle.language.jvm.tasks.ProcessResources
+import net.fabricmc.loom.api.LoomGradleExtensionAPI
 
 plugins {
     kotlin("jvm") version "2.2.10"
     id("com.google.devtools.ksp") version "2.2.10-2.0.2"
-    id("fabric-loom")
+    // `apply false` puts loom on the classpath without applying it; the actual
+    // plugin (obfuscated vs deobfuscated) is picked per-version below. Typed DSL
+    // accessors are not generated under `apply false`, so loom-specific config in
+    // this file uses the string-based DSL (`"minecraft"(...)`, `configure<LoomGradleExtensionAPI>`).
+    id("fabric-loom") apply false
+    id("net.fabricmc.fabric-loom") apply false
     id("multiloader-loader")
     id("dev.kikugie.fletching-table.fabric") version "0.1.0-alpha.22"
 }
@@ -11,6 +17,17 @@ plugins {
 val mod_id = commonMod.prop("mod_id")
 val minecraft_version = commonMod.prop("minecraft_version")
 var mod_version = project.version.toString()
+
+// MC 26.1 ships deobfuscated, so Loom 1.15+ skips the mappings layer and the
+// remap step. The non-obfuscated plugin `net.fabricmc.fabric-loom` routes to
+// `LoomNoRemapGradlePlugin`; the legacy `fabric-loom` alias still targets the
+// obfuscated-MC plugin used for 1.21.x. Both IDs come from the same JAR and
+// cannot be conditionalised inside the `plugins { }` block, so we apply the
+// correct one here.
+val isDeobfuscatedMc = minecraft_version.startsWith("26.")
+apply(plugin = if (isDeobfuscatedMc) "net.fabricmc.fabric-loom" else "fabric-loom")
+
+val loom = extensions.getByType(LoomGradleExtensionAPI::class.java)
 
 base {
     archivesName.set("$mod_id-$minecraft_version-fabric-$mod_version")
@@ -24,31 +41,37 @@ val extensionJars by configurations.creating {
 
 // Gradle is stupid and will throw a `Type mismatch: inferred type is Dependency? but Any was expected` otherwise
 fun DependencyHandlerScope.implInclude(notation: Any) {
-    add("implementation", requireNotNull(include(notation)))
+    val dep = requireNotNull(add("include", notation))
+    add("implementation", dep)
 }
 
 dependencies {
-    minecraft("com.mojang:minecraft:$minecraft_version")
+    "minecraft"("com.mojang:minecraft:$minecraft_version")
 
-    mappings(loom.layered {
-        val parchment_minecraft = commonMod.prop("parchment_minecraft")
-        val parchment_version = commonMod.prop("parchment_version")
+    if (!isDeobfuscatedMc) {
+        "mappings"(loom.layered(Action {
+            val parchment_minecraft = commonMod.prop("parchment_minecraft")
+            val parchment_version = commonMod.prop("parchment_version")
 
-        officialMojangMappings()
-        parchment(
-            "org.parchmentmc.data:parchment-$parchment_minecraft:$parchment_version@zip"
-        )
-    })
+            officialMojangMappings()
+            // Parchment does not yet ship mappings for 26.1.x; skip the layer when
+            // either property is blank. TODO(26.1): re-enable once parchment publishes.
+            if (parchment_minecraft.isNotBlank() && parchment_version.isNotBlank()) {
+                parchment(
+                    "org.parchmentmc.data:parchment-$parchment_minecraft:$parchment_version@zip"
+                )
+            }
+        }))
+    }
 
     val fabric_loader_version = commonMod.prop("fabric_loader_version")
     val fabric_version = commonMod.prop("fabric_version")
+    val mod_menu_version = commonMod.prop("mod_menu_version")
 
-    modImplementation("net.fabricmc:fabric-loader:$fabric_loader_version")
-    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabric_version")
-
-    // ModMenu integration
-    val mod_menu_version = commonMod.prop("mod_menu_version");
-    modImplementation("com.terraformersmc:modmenu:$mod_menu_version")
+    val modOrPlain = if (isDeobfuscatedMc) "implementation" else "modImplementation"
+    add(modOrPlain, "net.fabricmc:fabric-loader:$fabric_loader_version")
+    add(modOrPlain, "net.fabricmc.fabric-api:fabric-api:$fabric_version")
+    add(modOrPlain, "com.terraformersmc:modmenu:$mod_menu_version")
 
     // Common library dependencies - include for bundling in jar
     implInclude("io.noties:prism4j:2.0.0")
@@ -91,13 +114,13 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 // Copy the version-specific access widener and rename it for the jar
-loom {
+loom.apply {
     // Use the version-specific access widener
     accessWidenerPath.set(project(":common").file("src/main/resources/accesswideners/$minecraft_version-$mod_id.accesswidener"))
 
-    mixin {
+    mixin(Action {
         defaultRefmapName.set("$mod_id.refmap.json")
-    }
+    })
 }
 
 fletchingTable {

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/JsMacrosFabric.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/JsMacrosFabric.java
@@ -3,7 +3,11 @@ package com.jsmacrosce.jsmacros.fabric.client;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+//? if >=26.1 {
+/*import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
+*///?} else {
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+//?}
 import com.jsmacrosce.jsmacros.client.JsMacros;
 import com.jsmacrosce.jsmacros.client.JsMacrosClient;
 import com.jsmacrosce.jsmacros.client.api.classes.inventory.CommandManager;
@@ -17,7 +21,11 @@ public class JsMacrosFabric implements ModInitializer, ClientModInitializer {
     public void onInitializeClient() {
         JsMacrosClient.onInitializeClient();
         ClientTickEvents.END_CLIENT_TICK.register(TickBasedEvents::onTick);
+        //? if >=26.1 {
+        /*KeyMappingHelper.registerKeyMapping(JsMacrosClient.keyBinding);
+        *///?} else {
         KeyBindingHelper.registerKeyBinding(JsMacrosClient.keyBinding);
+        //?}
         CommandBuilderFabric.registerEvent();
     }
 

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/api/classes/CommandBuilderFabric.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/api/classes/CommandBuilderFabric.java
@@ -6,7 +6,15 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
+//? if >=26.1 {
+/*import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.getActiveDispatcher;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
+*///?} else {
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.getActiveDispatcher;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
+//?}
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.Minecraft;
@@ -31,24 +39,32 @@ public class CommandBuilderFabric extends CommandBuilder {
     private final Stack<Pair<Boolean, Function<CommandBuildContext, ArgumentBuilder<FabricClientCommandSource, ?>>>> pointer = new Stack<>();
 
     public CommandBuilderFabric(String name) {
-        Function<CommandBuildContext, ArgumentBuilder<FabricClientCommandSource, ?>> head = (a) -> ClientCommandManager.literal(name);
+        Function<CommandBuildContext, ArgumentBuilder<FabricClientCommandSource, ?>> head = (a) -> literal(name);
         this.name = name;
         pointer.push(new Pair<>(false, head));
     }
 
     @Override
     protected void argument(String name, Supplier<ArgumentType<?>> type) {
+        //? if >=26.1 {
+        /*pointer.push(new Pair<>(true, (e) -> ClientCommands.argument(name, type.get())));
+        *///?} else {
         pointer.push(new Pair<>(true, (e) -> ClientCommandManager.argument(name, type.get())));
+        //?}
     }
 
     @Override
     protected void argument(String name, Function<CommandBuildContext, ArgumentType<?>> type) {
+        //? if >=26.1 {
+        /*pointer.push(new Pair<>(true, (e) -> ClientCommands.argument(name, type.apply(e))));
+        *///?} else {
         pointer.push(new Pair<>(true, (e) -> ClientCommandManager.argument(name, type.apply(e))));
+        //?}
     }
 
     @Override
     public CommandBuilder literalArg(String name) {
-        pointer.push(new Pair<>(false, (e) -> ClientCommandManager.literal(name)));
+        pointer.push(new Pair<>(false, (e) -> literal(name)));
         return this;
     }
 
@@ -94,7 +110,7 @@ public class CommandBuilderFabric extends CommandBuilder {
     @Override
     public CommandBuilder register() {
         or(1);
-        CommandDispatcher<FabricClientCommandSource> dispatcher = ClientCommandManager.getActiveDispatcher();
+        CommandDispatcher<FabricClientCommandSource> dispatcher = getActiveDispatcher();
         Function<CommandBuildContext, ArgumentBuilder<FabricClientCommandSource, ?>> head = pointer.pop().getU();
         if (dispatcher != null) {
             ClientPacketListener networkHandler = Minecraft.getInstance().getConnection();
@@ -110,7 +126,7 @@ public class CommandBuilderFabric extends CommandBuilder {
 
     @Override
     public CommandBuilder unregister() throws IllegalAccessException {
-        CommandNodeAccessor.remove(ClientCommandManager.getActiveDispatcher().getRoot(), name);
+        CommandNodeAccessor.remove(getActiveDispatcher().getRoot(), name);
         ClientPacketListener p = Minecraft.getInstance().getConnection();
         if (p != null) {
             CommandDispatcher<?> cd = p.getCommands();

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/api/classes/CommandManagerFabric.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/api/classes/CommandManagerFabric.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.fabric.client.api.classes;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.CommandNode;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+//? if >=26.1 {
+/*import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.getActiveDispatcher;
+*///?} else {
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.getActiveDispatcher;
+//?}
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import com.jsmacrosce.jsmacros.client.access.CommandNodeAccessor;
@@ -19,7 +23,7 @@ public class CommandManagerFabric extends CommandManager {
 
     @Override
     public CommandNodeHelper unregisterCommand(String command) throws IllegalAccessException {
-        CommandNode<?> cnf = CommandNodeAccessor.remove(ClientCommandManager.getActiveDispatcher().getRoot(), command);
+        CommandNode<?> cnf = CommandNodeAccessor.remove(getActiveDispatcher().getRoot(), command);
         CommandNode<?> cn = null;
         ClientPacketListener p = Minecraft.getInstance().getConnection();
         if (p != null) {
@@ -32,7 +36,7 @@ public class CommandManagerFabric extends CommandManager {
     @Override
     public void reRegisterCommand(CommandNodeHelper node) {
         if (node.fabric != null) {
-            ClientCommandManager.getActiveDispatcher().getRoot().addChild((CommandNode) node.fabric);
+            getActiveDispatcher().getRoot().addChild((CommandNode) node.fabric);
         }
         ClientPacketListener nh = Minecraft.getInstance().getConnection();
         if (nh != null) {

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinDebugHud.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinDebugHud.java
@@ -2,7 +2,9 @@ package com.jsmacrosce.jsmacros.fabric.client.mixins.access;
 
 import com.google.common.collect.ImmutableSet;
 import dev.kikugie.fletching_table.annotation.MixinEnvironment;
+//? if <=1.21.8 {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.components.DebugScreenOverlay;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinGameRenderer.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinGameRenderer.java
@@ -2,7 +2,11 @@ package com.jsmacrosce.jsmacros.fabric.client.mixins.access;
 
 import dev.kikugie.fletching_table.annotation.MixinEnvironment;
 import net.minecraft.client.Minecraft;
+//? if >=26.1 {
+/*import net.minecraft.client.gui.GuiGraphicsExtractor;
+*///?} else {
 import net.minecraft.client.gui.GuiGraphics;
+//?}
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Final;
@@ -23,26 +27,38 @@ public class MixinGameRenderer {
     @Final
     private Minecraft minecraft;
 
-//? if >1.21.8 {
-    /*@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;renderWithTooltipAndSubtitles(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"))
-*///?} else {
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;renderWithTooltip(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"))
-//?}
-    private void onRender(Screen instance, GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        //? if >1.21.8 {
-        /*instance.renderWithTooltipAndSubtitles(drawContext, mouseX, mouseY, delta);
-        *///?} else {
-        instance.renderWithTooltip(drawContext, mouseX, mouseY, delta);
-        //?}
+//? if >=26.1 {
+    /*@Redirect(method = "extractGui", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;extractRenderStateWithTooltipAndSubtitles(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V"))
+    private void onRender(Screen instance, GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta) {
+        instance.extractRenderStateWithTooltipAndSubtitles(drawContext, mouseX, mouseY, delta);
         if (!(minecraft.screen instanceof ScriptScreen)) {
             ((IScreenInternal) instance).jsmacros_render(drawContext, mouseX, mouseY, delta);
         }
     }
+    *///?} else if >1.21.8 {
+    /*@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;renderWithTooltipAndSubtitles(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"))
+    private void onRender(Screen instance, GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        instance.renderWithTooltipAndSubtitles(drawContext, mouseX, mouseY, delta);
+        if (!(minecraft.screen instanceof ScriptScreen)) {
+            ((IScreenInternal) instance).jsmacros_render(drawContext, mouseX, mouseY, delta);
+        }
+    }
+    *///?} else {
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;renderWithTooltip(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"))
+    private void onRender(Screen instance, GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        instance.renderWithTooltip(drawContext, mouseX, mouseY, delta);
+        if (!(minecraft.screen instanceof ScriptScreen)) {
+            ((IScreenInternal) instance).jsmacros_render(drawContext, mouseX, mouseY, delta);
+        }
+    }
+    //?}
 
+    //? if <26.1 {
     @Inject(at = @At("HEAD"), method = "pick(F)V", cancellable = true)
     public void onTargetUpdate(float tickDelta, CallbackInfo ci) {
         if (InteractionProxy.Target.onUpdate(tickDelta)) {
             ci.cancel();
         }
     }
+    //?}
 }

--- a/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinKeyboard.java
+++ b/fabric/src/main/java/com/jsmacrosce/jsmacros/fabric/client/mixins/access/MixinKeyboard.java
@@ -17,7 +17,20 @@ import net.minecraft.client.input.KeyEvent;
 @MixinEnvironment("fabric")
 @Mixin(KeyboardHandler.class)
 public class MixinKeyboard {
-    //? if >1.21.8 {
+    //? if >=26.1 {
+    /*@WrapOperation(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;keyPressed(Lnet/minecraft/client/input/KeyEvent;)Z"))
+    private boolean onKeyPressed(Screen instance, KeyEvent keyEvent, Operation<Boolean> original) {
+        ((IScreenInternal) instance).jsmacros_keyPressed(keyEvent.key(), keyEvent.scancode(), keyEvent.modifiers());
+        return original.call(instance, keyEvent);
+    }
+
+    @WrapOperation(method = "charTyped", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;charTyped(Lnet/minecraft/client/input/CharacterEvent;)Z"))
+    private boolean onCharTyped1(Screen instance, CharacterEvent characterEvent, Operation<Boolean> original) {
+        // 26.1's CharacterEvent is char-only by design — modifier bits only travel with KeyEvent now.
+        ((IScreenInternal) instance).jsmacros_charTyped((char) characterEvent.codepoint(), 0);
+        return original.call(instance, characterEvent);
+    }
+    *///?} else if >1.21.8 {
     /*@WrapOperation(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;keyPressed(Lnet/minecraft/client/input/KeyEvent;)Z"))
     private boolean onKeyPressed(Screen instance, KeyEvent keyEvent, Operation<Boolean> original) {
         ((IScreenInternal) instance).jsmacros_keyPressed(keyEvent.key(), keyEvent.scancode(), keyEvent.modifiers());

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,8 +43,13 @@ pluginManagement {
     }
 
     plugins {
-        // see https://fabricmc.net/develop/ for new versions
-        id("fabric-loom") version "1.13-SNAPSHOT" apply false
+        // see https://fabricmc.net/develop/ for new versions.
+        // fabric-loom is the legacy alias (LoomGradlePlugin, requires mappings) used for 1.21.x.
+        // net.fabricmc.fabric-loom is the non-obfuscated plugin (LoomNoRemapGradlePlugin, skips
+        // mappings) required for MC 26.1+ which ships deobfuscated. Both IDs resolve to the same
+        // plugin JAR.
+        id("fabric-loom") version "1.15.4" apply false
+        id("net.fabricmc.fabric-loom") version "1.15.4" apply false
         // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
         id("net.neoforged.moddev") version "2.0.139" apply false
     }
@@ -67,21 +72,31 @@ include("extension:graal:js")
 include("extension:graal:python")
 include("extension:ruby")
 
+val fabricVersions = listOf("1.21.5", "1.21.8", "1.21.10", "1.21.11", "26.1.2")
+val commonVersions = fabricVersions
+// NeoForge 26.1.2.22-beta is available but requires its own adaptation; deferred to a follow-up PR.
+// TODO(26.1): include "26.1.2" here once the neoforge branch is wired up.
+val neoforgeVersions = listOf("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+
+// Expose to stonecutter.gradle.kts so version lists aren't duplicated.
+gradle.extra["fabricVersions"] = fabricVersions
+gradle.extra["neoforgeVersions"] = neoforgeVersions
+
 stonecutter {
     kotlinController = true
     centralScript = "build.gradle.kts"
 
     create(rootProject) {
-        versions("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+        versions(*fabricVersions.toTypedArray())
 
         branch("common") {
-            versions("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+            versions(*commonVersions.toTypedArray())
         }
         branch("fabric") {
-            versions("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+            versions(*fabricVersions.toTypedArray())
         }
         branch("neoforge") {
-            versions("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+            versions(*neoforgeVersions.toTypedArray())
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ include("extension")
 include("extension:graal")
 include("extension:graal:js")
 include("extension:graal:python")
+include("extension:ruby")
 
 stonecutter {
     kotlinController = true

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -145,7 +145,8 @@ val loaders = listOf("fabric", "neoforge")
 
 data class ExtensionSpec(val path: String, val extId: String)
 val jsmExtensions: List<ExtensionSpec> = listOf(
-    ExtensionSpec(path = ":extension:graal:python", extId = "graalpy")
+    ExtensionSpec(path = ":extension:graal:python", extId = "graalpy"),
+    ExtensionSpec(path = ":extension:ruby", extId = "jruby")
 )
 
 val artifactBaseName = providers.provider { "$modId-$mcVersion-$channel-$version" }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -10,6 +10,7 @@ import org.gradle.external.javadoc.CoreJavadocOptions
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.api.GradleException
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import java.io.File
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -18,9 +19,14 @@ import java.util.Locale
 import java.util.Properties
 
 plugins {
+    // java-base is needed at the root so the aggregate javadoc tasks can
+    // resolve a JavaToolchainService for pinning to JDK 25 (required to read
+    // 26.1's class file version 69).
+    `java-base`
     id("dev.kikugie.stonecutter")
-    id("net.neoforged.moddev") version "2.0.139" apply false
-    id("fabric-loom") version "1.13-SNAPSHOT" apply false
+    id("net.neoforged.moddev") apply false
+    id("fabric-loom") apply false
+    id("net.fabricmc.fabric-loom") apply false
     id("me.modmuss50.mod-publish-plugin") version "1.1.0"
 }
 
@@ -41,16 +47,12 @@ repositories {
     }
 
     exclusiveContent {
-        forRepositories(
+        forRepository {
             maven {
                 name = "ParchmentMC"
                 url = uri("https://maven.parchmentmc.org/")
-            },
-            maven {
-                name = "NeoForge"
-                url = uri("https://maven.neoforged.net/releases")
             }
-        )
+        }
         filter {
             includeGroup("org.parchmentmc.data")
         }
@@ -137,11 +139,24 @@ val modId = modIdProvider.get()
 val channel = channelProvider.get()
 version = computedVersionProvider.get()
 
-val supportedVersions = listOf("1.21.5", "1.21.8", "1.21.10", "1.21.11")
+@Suppress("UNCHECKED_CAST")
+val supportedVersions = gradle.extra["fabricVersions"] as List<String>
+@Suppress("UNCHECKED_CAST")
+val neoforgeVersions = gradle.extra["neoforgeVersions"] as List<String>
 val mcVersionsToBuild = if (IS_CI) supportedVersions else listOf("1.21.11")
 val mcVersion = mcVersionsToBuild.first() // for backward compatibility
 
 val loaders = listOf("fabric", "neoforge")
+
+val neoforgeUnsupportedVersions = (supportedVersions - neoforgeVersions.toSet()).toSet()
+fun loadersFor(mcVersion: String): List<String> =
+    if (mcVersion in neoforgeUnsupportedVersions) loaders.filterNot { it == "neoforge" } else loaders
+
+// MC 26.1+ ships deobfuscated; the non-obfuscated Loom plugin skips remapping
+// and does not register a remapJar task, so packaging falls back to the plain
+// jar task on those versions.
+fun fabricArtifactTask(mcVersion: String): String =
+    if (mcVersion.startsWith("26.")) "jar" else "remapJar"
 
 data class ExtensionSpec(val path: String, val extId: String)
 val jsmExtensions: List<ExtensionSpec> = listOf(
@@ -280,6 +295,13 @@ gradle.projectsEvaluated {
         }
     }
 
+    // 26.1.x targets Java 25 bytecode, so the aggregate javadoc tasks must run
+    // on a JDK that can read class file version 69. Pin all three to JDK 25 via
+    // the toolchain service; foojay auto-provisions if missing.
+    val docsJavadocTool = javaToolchains.javadocToolFor {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+
     tasks.register("generatePyDoc", Javadoc::class.java) {
         group = "documentation"
         description = "Generates the python documentation for the project"
@@ -287,6 +309,7 @@ gradle.projectsEvaluated {
         classpath = documentationClasspath
         dependsOn(minecraftArtifactTasks)
         destinationDir = File(docsBuildDir, "python/JsMacrosAC")
+        javadocTool.set(docsJavadocTool)
         options.doclet = "com.jsmacrosce.doclet.pydoclet.Main"
         options.docletpath = mutableListOf(docletJarFile)
         (options as CoreJavadocOptions).addStringOption("v", project.version.toString())
@@ -307,6 +330,7 @@ gradle.projectsEvaluated {
         classpath = documentationClasspath
         dependsOn(minecraftArtifactTasks)
         destinationDir = File(docsBuildDir, "typescript/headers")
+        javadocTool.set(docsJavadocTool)
         options.doclet = "com.jsmacrosce.doclet.tsdoclet.Main"
         options.docletpath = mutableListOf(docletJarFile)
         (options as CoreJavadocOptions).addStringOption("v", project.version.toString())
@@ -327,6 +351,7 @@ gradle.projectsEvaluated {
         classpath = documentationClasspath
         dependsOn(minecraftArtifactTasks)
         destinationDir = File(docsBuildDir, "web")
+        javadocTool.set(docsJavadocTool)
         options.doclet = "com.jsmacrosce.doclet.webdoclet.Main"
         options.docletpath = mutableListOf(docletJarFile)
         (options as CoreJavadocOptions).addStringOption("v", project.version.toString())
@@ -360,10 +385,10 @@ gradle.projectsEvaluated {
 
     // Package loader-specific jars
     val baseJarTasks: Map<String, org.gradle.api.tasks.TaskProvider<Copy>> =
-        loaders.flatMap { loader ->
-            mcVersionsToBuild.map { version ->
+        mcVersionsToBuild.flatMap { version ->
+            loadersFor(version).map { loader ->
                 val loaderProject = project(":$loader:$version")
-                val sourceTaskName = if (loader == "fabric") "remapJar" else "jar"
+                val sourceTaskName = if (loader == "fabric") fabricArtifactTask(version) else "jar"
                 val taskName = "package${loader.replaceFirstChar { it.uppercase() }}ModJar${version.replace(".", "")}"
 
                 tasks.register(taskName, Copy::class.java) {
@@ -495,9 +520,9 @@ gradle.projectsEvaluated {
         if (publishModrinth) {
             mcVersionsToBuild.forEach { targetMcVersion ->
                 val mcSegment = targetMcVersion.replace(".", "")
-                loaders.forEach { loader ->
+                loadersFor(targetMcVersion).forEach { loader ->
                     val platformName = "modrinth${loader.replaceFirstChar { it.uppercase() }}$mcSegment"
-                    val sourceTaskName = if (loader == "fabric") "remapJar" else "jar"
+                    val sourceTaskName = if (loader == "fabric") fabricArtifactTask(targetMcVersion) else "jar"
                     val loaderProject = project(":$loader:$targetMcVersion")
 
                     modrinth(platformName) {

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -1,0 +1,25 @@
+minecraft_version=26.1.2
+minecraft_version_range=[26.1.2]
+# MC 26.1.x requires Java 25 at runtime; override the root gradle.properties
+# java_version=21. foojay-resolver will auto-provision JDK 25.
+java_version=25
+## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
+## https://projects.neoforged.net/neoforged/neoform
+neo_form_version=26.1.2-1
+# ParchmentMC does not yet publish mappings for 26.1.x (latest is 1.21.11).
+# These properties are intentionally blank; fabric/build.gradle.kts skips the
+# parchment layer when they are empty. TODO(26.1): re-enable once parchment ships.
+parchment_minecraft=
+parchment_version=
+
+# Fabric, see https://fabricmc.net/develop/ for new versions
+fabric_version=0.146.1+26.1.2
+fabric_loader_version=0.19.2
+
+# NeoForge 26.1.2 has not been released yet (latest is 26.1.1.15-beta).
+# These are intentionally blank; the neoforge branch does not include 26.1.2.
+neoforge_version=
+neoforge_loader_version_range=[4,)
+
+# https://modrinth.com/mod/modmenu/versions?g=26.1.2
+mod_menu_version=18.0.0-alpha.8


### PR DESCRIPTION
> **Reopened from #22.**
>
> **Stacked PR series — 2 of 3:**
> 1. #23 — Ruby scripting extension (1 commit)
> 2. **This PR** — Minecraft 26.1.2 support (cumulative: Ruby + MC 26.1)
> 3. #25 — Render-thread interrupt corruption fix (cumulative: Ruby + MC 26.1 + render)
>
> Branch contains the Ruby commit underneath the MC 26.1 commit; the diff vs `main` shows both. Review the MC 26.1 commit standalone for the actual changes here.
>
> Merging the 3rd PR (render) alone is sufficient to land all three commits in `main`; this PR will auto-close.

---

## What this PR does

Adds Minecraft **26.1.2** support to JsMacrosCE alongside the existing 1.21.5/8/10/11 targets, coordinated via [stonecutter](https://github.com/kikugie/stonecutter). All five Fabric jars build green; 26.1 launches clean in Fabulously Optimized and connects through to civmc.net.

The 26.1 port is a real overhaul — MC 26.1 ships **deobfuscated** (Mojang stopped publishing `client_mappings` from 26.x onward), split the GUI render pipeline into CPU extract + GPU render phases, and renamed a long tail of core classes (`GuiGraphics` → `GuiGraphicsExtractor`, `ClickType` → `ContainerInput`, `LightTexture` → `Brightness`/`LightCoordsUtil`, `ItemRenderer` → `ItemStackRenderState` + `ItemModelResolver`, etc). Most of the diff is behind `//? if >=26.1 {` stonecutter gates.

Commit message has the full breakdown of source-level adaptations, mixin retargeting, dedup helpers, justified gaps, and deferred follow-ups.

## Disclosure — Claude Opus 4.7 helped

Most of the mechanical rewrite surface here was produced with **Claude Opus 4.7 (1M context)**: per-file API-rename sweeps, mixin target rediscovery, stonecutter gate construction across ~60 common files + ~30 mixins + fabric build/settings plumbing, and a multi-pass `/simplify` review. Architectural decisions were mine; the typing was mostly Claude. Calling this out because the diff size reflects that amplification.

## Could be a lot cleaner if we drop 1.21.\*

Roughly **~40% of the diff is stonecutter gates keeping the <26.1 versions building**. All of that evaporates if the branch targets 26.1 only.

Suggested strategy: **land this as-is so 26.1 users aren't blocked, keep 1.21.x alive for a few releases so existing script users have runway, then drop the pre-26.1 branches in a follow-up**.

## Test plan

- [x] `./gradlew :fabric:1.21.5:jar :fabric:1.21.8:jar :fabric:1.21.10:jar :fabric:1.21.11:jar :fabric:26.1.2:jar` — all green
- [x] Runtime launch: Fabulously Optimized 26.1.2 boots clean, connects to play.civmc.net:25565
- [x] Older versions: 1.21.11 still runtime-clean (unchanged from main)
- [x] Runtime sanity on 1.21.5/8/10 (compile-verified only; no clients available to smoke-test)
